### PR TITLE
Add links between provided parameters definitions

### DIFF
--- a/framework/vendor/abstracts/AbstractBotCommand.java
+++ b/framework/vendor/abstracts/AbstractBotCommand.java
@@ -1,10 +1,5 @@
 package vendor.abstracts;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Collections;
-
 import net.dv8tion.jda.core.entities.*;
 import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.core.managers.AccountManager;
@@ -19,8 +14,13 @@ import vendor.objects.MessageEventDigger;
 import vendor.objects.Request;
 import vendor.objects.Request.Parameter;
 import vendor.res.FrameworkResources;
-import vendor.utilities.formatting.DiscordFormatter;
 import vendor.utilities.FrameworkTemplate;
+import vendor.utilities.formatting.DiscordFormatter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 
 public abstract class AbstractBotCommand extends Translatable implements
 		Emojis, Utils, LinkableCommand, FrameworkResources, DiscordFormatter {
@@ -417,8 +417,11 @@ public abstract class AbstractBotCommand extends Translatable implements
 	 *         Ressources followed by the <i>parameter</i> parameter.
 	 */
 	public String buildParameter(String parameter){
-		return String.join("", Collections.nCopies(parameter.length() > 1 ? 2 : 1,
-				String.valueOf(getRequest().getParametersPrefix()))) + parameter;
+		return String.join(
+				"",
+				Collections.nCopies(parameter.length() > 1 ? 2 : 1,
+						String.valueOf(getRequest().getParametersPrefix())))
+				+ parameter;
 	}
 	
 	/**

--- a/framework/vendor/abstracts/AbstractCommandRouter.java
+++ b/framework/vendor/abstracts/AbstractCommandRouter.java
@@ -8,7 +8,6 @@ import vendor.interfaces.Translatable;
 import vendor.interfaces.Utils;
 import vendor.objects.*;
 import vendor.res.FrameworkResources;
-import vendor.abstracts.AbstractBotCommand;
 
 public abstract class AbstractCommandRouter extends Thread implements Utils,
 		Translatable, FrameworkResources {

--- a/framework/vendor/objects/Request.java
+++ b/framework/vendor/objects/Request.java
@@ -6,6 +6,7 @@ import vendor.interfaces.Utils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -91,6 +92,7 @@ public class Request extends Translatable implements Utils {
 	private String commandPrefix;
 	
 	private HashMap<String, Parameter> parameters;
+	private HashMap<Parameter, ArrayList<String>> parametersLinks;
 	private char parametersPrefix;
 	
 	private String error;
@@ -283,11 +285,11 @@ public class Request extends Translatable implements Utils {
 	}
 	
 	public String getCommand(){
-		return command.substring(getCommandPrefix().length());
+		return this.getCommandNoFormat().substring(getCommandPrefix().length());
 	}
 	
 	public String getCommandNoFormat(){
-		return command;
+		return this.command;
 	}
 	
 	public void setCommand(String command){
@@ -295,7 +297,7 @@ public class Request extends Translatable implements Utils {
 	}
 	
 	public String getContent(){
-		return content;
+		return this.content;
 	}
 	
 	public void setContent(String content){
@@ -312,7 +314,11 @@ public class Request extends Translatable implements Utils {
 	}
 	
 	public HashMap<String, Parameter> getParameters(){
-		return parameters;
+		return this.parameters;
+	}
+	
+	public HashMap<Parameter, ArrayList<String>> getParametersLinks(){
+		return this.parametersLinks;
 	}
 	
 	public Parameter getParameter(String... parameterNames)
@@ -326,10 +332,22 @@ public class Request extends Translatable implements Utils {
 			
 			for(String parameterName : parameterNames){
 				
-				Parameter paramFound = getParameters().get(parameterName);
-				
-				if(paramFound != null)
-					return paramFound;
+				if(getParametersLinks() == null){
+					Parameter paramFound = getParameters().get(parameterName);
+					
+					if(paramFound != null)
+						return paramFound;
+				}
+				else{
+					
+					for(Map.Entry<Parameter, ArrayList<String>> entry : getParametersLinks().entrySet()){
+						
+						if(entry.getValue().contains(parameterName))
+               				return entry.getKey();
+						
+					}
+					
+				}
 				
 			}
 			
@@ -343,7 +361,7 @@ public class Request extends Translatable implements Utils {
 	}
 	
 	public char getParametersPrefix(){
-		return parametersPrefix;
+		return this.parametersPrefix;
 	}
 	
 	private String getParametersPrefixProtected(){
@@ -355,34 +373,35 @@ public class Request extends Translatable implements Utils {
 	}
 	
 	public boolean hasError(){
-		return error != null;
+		return this.getError() != null;
 	}
 	
-	public boolean hasParameter(String parameterName){
-		if(getParameters() == null)
-			return false;
+	// public boolean hasParameter(String parameterName){
+	// 	if(getParameters() == null)
+	// 		return false;
 		
-		return getParameters().containsKey(parameterName);
-	}
+	// 	return this.getParameters().containsKey(parameterName);
+	// }
 	
 	public boolean hasParameter(String... parameterNames){
 		
-		for(String parameterName : parameterNames)
-			if(this.hasParameter(parameterName))
-				return true;
-		
-		return false;
+		try{
+			return getParameter(parameterNames) != null;
+		}
+		catch(NoContentException e){
+			return false;
+		}
 		
 	}
 	
-	public boolean addParameter(String paramName){
-		return this.getParameters().put(paramName, new Parameter(paramName)) == null;
-	}
+	// public boolean addParameter(String paramName){
+	// 	return this.getParameters().put(paramName, new Parameter(paramName)) == null;
+	// }
 	
-	public boolean addParameter(String paramName, String paramContent){
-		return this.getParameters().put(paramName,
-				new Parameter(paramName, paramContent)) == null;
-	}
+	// public boolean addParameter(String paramName, String paramContent){
+	// 	return this.getParameters().put(paramName,
+	// 			new Parameter(paramName, paramContent)) == null;
+	// }
 	
 	private String[] splitCommandAndContent(String command){
 		
@@ -449,6 +468,29 @@ public class Request extends Translatable implements Utils {
 			this.error = message.toString();
 			
 		}
+		
+	}
+	
+	public void setParamLinkMap(ArrayList<ArrayList<String>> map){
+		
+		getParameters().forEach((key, param) -> {
+			
+			for(ArrayList<String> paramsGroup : map){
+				
+				if(paramsGroup.contains(key)){
+					
+					if(this.parametersLinks == null){
+						this.parametersLinks = new HashMap<>();
+					}
+					
+					this.parametersLinks.put(param, paramsGroup);
+					break;
+					
+				}
+				
+			}
+			
+		});
 		
 	}
 	

--- a/framework/vendor/objects/Request.java
+++ b/framework/vendor/objects/Request.java
@@ -340,10 +340,11 @@ public class Request extends Translatable implements Utils {
 				}
 				else{
 					
-					for(Map.Entry<Parameter, ArrayList<String>> entry : getParametersLinks().entrySet()){
+					for(Map.Entry<Parameter, ArrayList<String>> entry : getParametersLinks()
+							.entrySet()){
 						
 						if(entry.getValue().contains(parameterName))
-               				return entry.getKey();
+							return entry.getKey();
 						
 					}
 					
@@ -379,7 +380,7 @@ public class Request extends Translatable implements Utils {
 	// public boolean hasParameter(String parameterName){
 	// 	if(getParameters() == null)
 	// 		return false;
-		
+	
 	// 	return this.getParameters().containsKey(parameterName);
 	// }
 	
@@ -473,24 +474,25 @@ public class Request extends Translatable implements Utils {
 	
 	public void setParamLinkMap(ArrayList<ArrayList<String>> map){
 		
-		getParameters().forEach((key, param) -> {
-			
-			for(ArrayList<String> paramsGroup : map){
+		if(getParameters() != null)
+			getParameters().forEach((key, param) -> {
 				
-				if(paramsGroup.contains(key)){
+				for(ArrayList<String> paramsGroup : map){
 					
-					if(this.parametersLinks == null){
-						this.parametersLinks = new HashMap<>();
+					if(paramsGroup.contains(key)){
+						
+						if(this.parametersLinks == null){
+							this.parametersLinks = new HashMap<>();
+						}
+						
+						this.parametersLinks.put(param, paramsGroup);
+						break;
+						
 					}
-					
-					this.parametersLinks.put(param, paramsGroup);
-					break;
 					
 				}
 				
-			}
-			
-		});
+			});
 		
 	}
 	

--- a/src/app/CommandRouter.java
+++ b/src/app/CommandRouter.java
@@ -1,5 +1,7 @@
 package app;
 
+import java.util.ArrayList;
+
 import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 import utilities.abstracts.SimpleTextCommand;
 import utilities.interfaces.*;
@@ -109,6 +111,18 @@ public class CommandRouter extends AbstractCommandRouter implements Resources,
 				}
 				
 				try{
+					
+					ParametersHelp[] commandParamsHelp = getAbstractBotCommand().getParametersDescriptions();
+					
+					if(commandParamsHelp != null){
+						ArrayList<ArrayList<String>> paramsHelpMap = new ArrayList<>();
+						
+						for(ParametersHelp commandParamHelp : commandParamsHelp){
+							paramsHelpMap.add(commandParamHelp.getAllParams());
+						}
+						
+						getRequest().setParamLinkMap(paramsHelpMap);
+					}
 					
 					getAbstractBotCommand().action();
 					

--- a/src/app/CommandRouter.java
+++ b/src/app/CommandRouter.java
@@ -1,11 +1,12 @@
 package app;
 
-import java.util.ArrayList;
-
+import errorHandling.BotError;
+import errorHandling.BotErrorPrivate;
 import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 import utilities.abstracts.SimpleTextCommand;
-import utilities.interfaces.*;
-import utilities.specifics.*;
+import utilities.interfaces.Commands;
+import utilities.interfaces.Resources;
+import utilities.specifics.CommandConfirmed;
 import vendor.abstracts.AbstractCommandRouter;
 import vendor.exceptions.NoCommandException;
 import vendor.interfaces.Command;
@@ -13,11 +14,11 @@ import vendor.interfaces.Emojis;
 import vendor.interfaces.Utils;
 import vendor.modules.Logger;
 import vendor.objects.*;
-import errorHandling.BotError;
-import errorHandling.BotErrorPrivate;
 import vendor.utilities.CommandsThreadManager;
 import vendor.utilities.formatting.DiscordFormatter;
 import vendor.utilities.settings.Setting;
+
+import java.util.ArrayList;
 
 public class CommandRouter extends AbstractCommandRouter implements Resources,
 		Commands, Emojis, DiscordFormatter {
@@ -84,7 +85,7 @@ public class CommandRouter extends AbstractCommandRouter implements Resources,
 					if(request.hasError()){
 						setCommand(new BotError(request.getError(), false));
 						
-						getCommand().action();
+						getAbstractBotCommand().action();
 						setCommand(null);
 					}
 					
@@ -112,7 +113,8 @@ public class CommandRouter extends AbstractCommandRouter implements Resources,
 				
 				try{
 					
-					ParametersHelp[] commandParamsHelp = getAbstractBotCommand().getParametersDescriptions();
+					ParametersHelp[] commandParamsHelp = getAbstractBotCommand()
+							.getParametersDescriptions();
 					
 					if(commandParamsHelp != null){
 						ArrayList<ArrayList<String>> paramsHelpMap = new ArrayList<>();


### PR DESCRIPTION
This PR adds the ability to the `Request` object to handle a param mapping, so that if we call the method `hasParameter("s")` and a mapping linking the parameters `s` and `silent` is present, even if the user enters `!!hello --silent`, the method `hasParameter("s")` will return true.

To create that mapping, we need to call the (new) method `setParamLinkMap(ArrayList<ArrayList<String>> map)`, which accepts an arraylist of arraylist of links. Basically, the way the the links are created is via groups, and you can have multiple groups (hence the arraylist inception) which we say : "_all of the parameters in this group are all linked with each other_".

Example used in this PR in `CommandRouter` :
```java
ParametersHelp[] commandParamsHelp = getAbstractBotCommand().getParametersDescriptions();

ArrayList<ArrayList<String>> paramsHelpMap = new ArrayList<>();
						
for(ParametersHelp commandParamHelp : commandParamsHelp){
	paramsHelpMap.add(commandParamHelp.getAllParams());
}

// Preferably, paramsHelpMap is not null here
getRequest().setParamLinkMap(paramsHelpMap);
```

Thing to keep in mind : the mapping is done only to parameters that are already in the request : that means you have to initialize the request _before_ calling `setParamLinkMap` or otherwise the method will crash. This was made so the mapping does not override the current request and still tracks which parameters has been used in the request.

Closes #85