### PR TITLE
Add convertion from special format for variables to replacement friendly

### DIFF
--- a/framework/vendor/objects/Dictionary.java
+++ b/framework/vendor/objects/Dictionary.java
@@ -1,12 +1,12 @@
 package vendor.objects;
 
-import java.util.Locale;
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
-
 import vendor.interfaces.Utils;
 import vendor.modules.Logger;
 import vendor.modules.Logger.LogType;
+
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
 
 public class Dictionary implements Utils {
 	
@@ -84,10 +84,6 @@ public class Dictionary implements Utils {
 	}
 	
 	public String getString(String key, String possiblePrefix){
-		return this.getString(true, key, possiblePrefix);
-	}
-	
-	public String getString(boolean usesSpecialNotation, String key, String possiblePrefix){
 		
 		if(key == null){
 			throw new IllegalArgumentException(
@@ -148,17 +144,12 @@ public class Dictionary implements Utils {
 			
 		}
 		
-		if(usesSpecialNotation){
-			return this.convertToSpecialNotation(string);
-		}
-		else{
-			return string;
-		}
+		return this.convertToSpecialNotation(string);
 		
 	}
 	
-	protected String convertToSpecialNotation(String string){
-		return string.replaceAll("\\{0+", "\\{")
+	protected String convertToSpecialNotation(String langString){
+		return langString.replaceAll("\\{0+", "\\{")
 				.replaceAll("\\{([1-9][0-9]*)\\}", "\\%$1\\$s")
 				.replaceAll("\\{\\^(0*[1-9][0-9]*)\\}", "\\{$1\\}");
 	}

--- a/framework/vendor/objects/Dictionary.java
+++ b/framework/vendor/objects/Dictionary.java
@@ -150,7 +150,7 @@ public class Dictionary implements Utils {
 	}
 	
 	protected String convertToSpecialNotation(String langString){
-		return Pattern.compile("[()\\[\\].+*?^$\\\\|]").matcher(langString)
+		return Pattern.compile("[()\\[\\].+?^$\\\\|]").matcher(langString)
 				.replaceAll("\\\\$0").replaceAll("\\{0+", "\\{")
 				.replaceAll("\\{([1-9][0-9]*)\\}", "\\%$1\\$s")
 				.replaceAll("\\{\\^(0*[1-9][0-9]*)\\}", "\\{$1\\}");

--- a/framework/vendor/objects/Dictionary.java
+++ b/framework/vendor/objects/Dictionary.java
@@ -7,6 +7,7 @@ import vendor.modules.Logger.LogType;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
+import java.util.regex.Pattern;
 
 public class Dictionary implements Utils {
 	
@@ -149,7 +150,8 @@ public class Dictionary implements Utils {
 	}
 	
 	protected String convertToSpecialNotation(String langString){
-		return langString.replaceAll("\\{0+", "\\{")
+		return Pattern.compile("[()\\[\\].+*?^$\\\\|]").matcher(langString)
+				.replaceAll("\\\\$0").replaceAll("\\{0+", "\\{")
 				.replaceAll("\\{([1-9][0-9]*)\\}", "\\%$1\\$s")
 				.replaceAll("\\{\\^(0*[1-9][0-9]*)\\}", "\\{$1\\}");
 	}

--- a/framework/vendor/objects/Dictionary.java
+++ b/framework/vendor/objects/Dictionary.java
@@ -84,6 +84,10 @@ public class Dictionary implements Utils {
 	}
 	
 	public String getString(String key, String possiblePrefix){
+		return this.getString(true, key, possiblePrefix);
+	}
+	
+	public String getString(boolean usesSpecialNotation, String key, String possiblePrefix){
 		
 		if(key == null){
 			throw new IllegalArgumentException(
@@ -144,8 +148,19 @@ public class Dictionary implements Utils {
 			
 		}
 		
-		return string;
+		if(usesSpecialNotation){
+			return this.convertToSpecialNotation(string);
+		}
+		else{
+			return string;
+		}
 		
+	}
+	
+	protected String convertToSpecialNotation(String string){
+		return string.replaceAll("\\{0+", "\\{")
+				.replaceAll("\\{([1-9][0-9]*)\\}", "\\%$1\\$s")
+				.replaceAll("\\{\\^(0*[1-9][0-9]*)\\}", "\\{$1\\}");
 	}
 	
 	private String handleKey(String key){

--- a/res/lang/strings_en_US.properties
+++ b/res/lang/strings_en_US.properties
@@ -22,7 +22,7 @@ CommandClearNoPermission=I do not have the permissions for that!
 CommandClearCannotBulkDeleteOld=One or more messages couldn't be deleted. Cannot bulk delete message more than 2 weeks old. Please try again earlier.
 
 CommandHelpContent=Help is here
-CommandHelpHelpSentMessage=*Help sent!*
+CommandHelpHelpSentMessage=Help sent!
 
 CommandStopSavedFromSpam=You have been saved from the spam {1}
 CommandStopNoCommandToStopMessage=No command with the name {1} was found, no action was taken.
@@ -31,7 +31,7 @@ CommandStopCommandNotStoppedMessage=The {1} command refused to stop. Ooo, scary.
 CommandStopBotCantStop=I CAN'T STOP
 
 CommandSpamSpam=Spam
-CommandSpamUsageStart=`{1}`
+CommandSpamUsageStart={1}
 CommandSpamUsageFirstLine=Send a default of {1} spam messages.
 CommandSpamUsageSecondLine=Send a **[number of spam]**.
 CommandSpamUsageThirdLine=Send a **[number of spam]** with a **[custom message]**.

--- a/res/lang/strings_en_US.properties
+++ b/res/lang/strings_en_US.properties
@@ -2,19 +2,19 @@ LanguageName=English
 
 Usage=Usage
 
-NoActionForCommand=*No actions created for the command* %1$s *- please make an idea in the __ideas__ text channel!*
+NoActionForCommand=*No actions created for the command* {1} *- please make an idea in the __ideas__ text channel!*
 TERMINATE=**Y** *O*__***~~U~~***__ __*C* **A**N__ **NO*__t_S*To** ~~P*T*~~ __he*B**O**T*
-CommandIsRunningError=Cannot run another instance of the command `%1$s` : it is already running.
-HelloResponse=Hello %1$s! ^.^
+CommandIsRunningError=Cannot run another instance of the command {1} : it is already running.
+HelloResponse=Hello {1}! ^.^
 MessageReceivedFromPrivateResponse=You must be in a server to interact with me!
 MessageIsOnlyPrefixResponse=... you wanted to call upon me or...?
 
 CommandUserHasNoPrivateChannel=User has no private channel, cancelling.
 CommandCannotDisconnectOrNotConnected=The bot can not be disconnected if it is not in a voice channel.
 
-CommandLanguageChangingLanguage=The language has been set to : `%1$s`!
+CommandLanguageChangingLanguage=The language has been set to : {1}!
 CommandLanguageNoTranslation=The bot hasn't been translated to that language!
-CommandLanguageNullContent=Usage : %1$s OR %2$s.
+CommandLanguageNullContent=Usage : {1} OR {2}.
 CommandLanguageNullContentUsage=language name
 
 CommandClearConfirmMessage=Are you sure you want to clear all messages?
@@ -24,38 +24,38 @@ CommandClearCannotBulkDeleteOld=One or more messages couldn't be deleted. Cannot
 CommandHelpContent=Help is here
 CommandHelpHelpSentMessage=*Help sent!*
 
-CommandStopSavedFromSpam=You have been saved from the spam %1$s
-CommandStopNoCommandToStopMessage=No command with the name `%1$s` was found, no action was taken.
-CommandStopCommandFullyStoppedMessage=The `%1$s` command was successfully stopped. %2$s
-CommandStopCommandNotStoppedMessage=The `%1$s` command refused to stop. Ooo, scary. (*It probably just wasn't implemented...*)
+CommandStopSavedFromSpam=You have been saved from the spam {1}
+CommandStopNoCommandToStopMessage=No command with the name `{1}` was found, no action was taken.
+CommandStopCommandFullyStoppedMessage=The `{1}` command was successfully stopped. {2}
+CommandStopCommandNotStoppedMessage=The `{1}` command refused to stop. Ooo, scary. (*It probably just wasn't implemented...*)
 CommandStopBotCantStop=I CAN'T STOP
 
 CommandSpamSpam=Spam
-CommandSpamUsageStart=`%1$s`
-CommandSpamUsageFirstLine=Send a default of %1$s spam messages.
+CommandSpamUsageStart=`{1}`
+CommandSpamUsageFirstLine=Send a default of {1} spam messages.
 CommandSpamUsageSecondLine=Send a **[number of spam]**.
 CommandSpamUsageThirdLine=Send a **[number of spam]** with a **[custom message]**.
 
 # START of Games Commands strings
-CommandGameInitialErrorUsage=Usage : %1$s.\nSeparate games using commas.
+CommandGameInitialErrorUsage=Usage : {1}.\nSeparate games using commas.
 CommandGameInitialGamesReadyToBeRolledMessage=The following games are now ready to be rolled :
-CommandGameInitialViewListAgainMessage=Enter the command %1$s to view this list again.
+CommandGameInitialViewListAgainMessage=Enter the command {1} to view this list again.
 
-CommandGameAddErrorUsage=Usage : %1$s.
-CommandGameAddAddedGameSuccessMessage=The game `%1$s` has been added to the pool!"
-CommandGameAddErrorNoPoolCreated=Your game pool is not yet created.\nYou can create a game pool using %1$s.
+CommandGameAddErrorUsage=Usage : {1}.
+CommandGameAddAddedGameSuccessMessage=The game `{1}` has been added to the pool!"
+CommandGameAddErrorNoPoolCreated=Your game pool is not yet created.\nYou can create a game pool using {1}.
 
-CommandGameRemoveErrorUsage=Usage : %1$s.\nYou could also input %2$s to remove all the games in the current pool.
-CommandGameRemoveRemovedGameSuccessMessage=The game `%1$s` has been removed from the game pool!
-CommandGameRemoveErrorNoSuchGame=There is no such game in your pool! Type %1$s to see which games you have in your pool.
+CommandGameRemoveErrorUsage=Usage : {1}.\nYou could also input {2} to remove all the games in the current pool.
+CommandGameRemoveRemovedGameSuccessMessage=The game `{1}` has been removed from the game pool!
+CommandGameRemoveErrorNoSuchGame=There is no such game in your pool! Type {1} to see which games you have in your pool.
 CommandGameRemoveIsNowEmpty=The game pool is now empty!
 CommandGameRemoveErrorEmptyPool=You cannot remove a game from an empty game pool!
 
 CommandGameRollNumberIsNotValid=The number inputted needs to be a positive number.
-CommandGameRollRolledGameMessage=You shall play : `%1$s`!
-CommandGameRollRolledMultipleGamesMessage=%1$s game selected is : `%2$s`.
-CommandGameRollErrorPoolEmpty=The game pool is empty!\nCreate a game pool using %1$s!
-CommandGameRollErrorUsageMessage=Usage :\n%1$s OR %2$s : Roll the dice once to get a random game.\n%3$s OR %4$s : Roll a random game for the inputted number of time.
+CommandGameRollRolledGameMessage=You shall play : `{1}`!
+CommandGameRollRolledMultipleGamesMessage={1} game selected is : `{2}`.
+CommandGameRollErrorPoolEmpty=The game pool is empty!\nCreate a game pool using {1}!
+CommandGameRollErrorUsageMessage=Usage :\n{1} OR {2} : Roll the dice once to get a random game.\n{3} OR {4} : Roll a random game for the inputted number of time.
 
 CommandGameListNoGamesInPoolMessage=No games in your pool mate!
 CommandGameListTitleOfList=Here are the games in your game pool :
@@ -63,7 +63,7 @@ CommandGameListTitleOfList=Here are the games in your game pool :
 GameInteractionCommandErrorUndefined=An unsuspected error happened. What have you done.
 # END of Games Commands strings
 
-CommandConfirmedCustomAndConfirmMessage=Enter %1$s to confirm. Entering %2$s will cancel the confirmation.\nAny other command will cancel the confirmation and execute the inputted command.
+CommandConfirmedCustomAndConfirmMessage=Enter {1} to confirm. Entering {2} will cancel the confirmation.\nAny other command will cancel the confirmation and execute the inputted command.
 CommandConfirmedConfCancelled=Confirmation cancelled
 
 # START of Music Commands strings
@@ -76,18 +76,18 @@ CommandMusicPauseAlreadyPaused=The bot is already paused!
 CommandMusicPauseSuccess=The music has been paused!
 
 CommandMusicSkipNotPlaying=You cannot skip anything when the bot is not playing!
-CommandMusicSkipSkippedNowPlaying=Skipped! Now playing : `%1$s`.
+CommandMusicSkipSkippedNowPlaying=Skipped! Now playing : `{1}`.
 CommandMusicSkipNoMoreMusic=No more music to the queue!
-CommandMusicSkipOverflowConfirm=Are you sure about that? You are trying to skip all the tracks as you entered a number (`%1$s`) higher than the remaining number of songs (`%2$s`) in the playlist.
+CommandMusicSkipOverflowConfirm=Are you sure about that? You are trying to skip all the tracks as you entered a number (`{1}`) higher than the remaining number of songs (`{2}`) in the playlist.
 
 CommandMusicSkippAllSkippedAllMusic=Skipped all music!
 
-CommandMusicVolumeChangedSuccess=The volume has been set to %1$s%%!
+CommandMusicVolumeChangedSuccess=The volume has been set to {1}%%!
 
-CommandMusicListNoList=The bot has no playlist right now. Add some with %1$s!
-CommandMusicListCurrentTrack=Current Track : `%1$s`
+CommandMusicListNoList=The bot has no playlist right now. Add some with {1}!
+CommandMusicListCurrentTrack=Current Track : `{1}`
 CommandMusicListHeader=Here's the current playlist!
-CommandMusicListTrackInfo=Track number `%1$s` : `%2$s`.
+CommandMusicListTrackInfo=Track number `{1}` : `{2}`.
 
 CommandMusicDisconnectNotConnected=The bot is not even connected!
 CommandMusicDisconnectSuccess=The bot successfully disconnected!
@@ -96,13 +96,13 @@ CommandMusicLoopNotPlaying=You cannot loop music when the bot is not playing!
 # END of Music Commands strings
 
 NumberNotANumber=Please use a number!
-NumberNotBetweenRange=Please enter a number between %1$s and %2$s.
+NumberNotBetweenRange=Please enter a number between {1} and {2}.
 
-MusicManagerTrackLoaded=`%1$s` has been added.
-MusicManagerPlaylistLoaded=Playlist `%1$s` has been added :
-MusicManagerPlaylistAddedTrackInfo=Added track `#%1$s` **->** `%2$s`.
-MusicManagerNoMatch=The song `%1$s` has not been found.
-MusicManagerLoadFailed=Cannot load the song : `%1$s`.
+MusicManagerTrackLoaded=`{1}` has been added.
+MusicManagerPlaylistLoaded=Playlist `{1}` has been added :
+MusicManagerPlaylistAddedTrackInfo=Added track `#{1}` **->** `{2}`.
+MusicManagerNoMatch=The song `{1}` has not been found.
+MusicManagerLoadFailed=Cannot load the song : `{1}`.
 
 StringTest=Hello!
-TestingReplacements=Hello %1$s!
+TestingReplacements=Hello {1}!

--- a/res/lang/strings_en_US.properties
+++ b/res/lang/strings_en_US.properties
@@ -25,9 +25,9 @@ CommandHelpContent=Help is here
 CommandHelpHelpSentMessage=*Help sent!*
 
 CommandStopSavedFromSpam=You have been saved from the spam {1}
-CommandStopNoCommandToStopMessage=No command with the name `{1}` was found, no action was taken.
-CommandStopCommandFullyStoppedMessage=The `{1}` command was successfully stopped. {2}
-CommandStopCommandNotStoppedMessage=The `{1}` command refused to stop. Ooo, scary. (*It probably just wasn't implemented...*)
+CommandStopNoCommandToStopMessage=No command with the name {1} was found, no action was taken.
+CommandStopCommandFullyStoppedMessage=The {1} command was successfully stopped. {2}
+CommandStopCommandNotStoppedMessage=The {1} command refused to stop. Ooo, scary. (*It probably just wasn't implemented...*)
 CommandStopBotCantStop=I CAN'T STOP
 
 CommandSpamSpam=Spam
@@ -42,18 +42,18 @@ CommandGameInitialGamesReadyToBeRolledMessage=The following games are now ready 
 CommandGameInitialViewListAgainMessage=Enter the command {1} to view this list again.
 
 CommandGameAddErrorUsage=Usage : {1}.
-CommandGameAddAddedGameSuccessMessage=The game `{1}` has been added to the pool!"
+CommandGameAddAddedGameSuccessMessage=The game {1} has been added to the pool!
 CommandGameAddErrorNoPoolCreated=Your game pool is not yet created.\nYou can create a game pool using {1}.
 
 CommandGameRemoveErrorUsage=Usage : {1}.\nYou could also input {2} to remove all the games in the current pool.
-CommandGameRemoveRemovedGameSuccessMessage=The game `{1}` has been removed from the game pool!
+CommandGameRemoveRemovedGameSuccessMessage=The game {1} has been removed from the game pool!
 CommandGameRemoveErrorNoSuchGame=There is no such game in your pool! Type {1} to see which games you have in your pool.
 CommandGameRemoveIsNowEmpty=The game pool is now empty!
 CommandGameRemoveErrorEmptyPool=You cannot remove a game from an empty game pool!
 
 CommandGameRollNumberIsNotValid=The number inputted needs to be a positive number.
-CommandGameRollRolledGameMessage=You shall play : `{1}`!
-CommandGameRollRolledMultipleGamesMessage={1} game selected is : `{2}`.
+CommandGameRollRolledGameMessage=You shall play : {1}!
+CommandGameRollRolledMultipleGamesMessage={1} game selected is : {2}.
 CommandGameRollErrorPoolEmpty=The game pool is empty!\nCreate a game pool using {1}!
 CommandGameRollErrorUsageMessage=Usage :\n{1} OR {2} : Roll the dice once to get a random game.\n{3} OR {4} : Roll a random game for the inputted number of time.
 
@@ -76,18 +76,18 @@ CommandMusicPauseAlreadyPaused=The bot is already paused!
 CommandMusicPauseSuccess=The music has been paused!
 
 CommandMusicSkipNotPlaying=You cannot skip anything when the bot is not playing!
-CommandMusicSkipSkippedNowPlaying=Skipped! Now playing : `{1}`.
+CommandMusicSkipSkippedNowPlaying=Skipped! Now playing : {1}.
 CommandMusicSkipNoMoreMusic=No more music to the queue!
-CommandMusicSkipOverflowConfirm=Are you sure about that? You are trying to skip all the tracks as you entered a number (`{1}`) higher than the remaining number of songs (`{2}`) in the playlist.
+CommandMusicSkipOverflowConfirm=Are you sure about that? You are trying to skip all the tracks as you entered a number ({1}) higher than the remaining number of songs ({2}) in the playlist.
 
 CommandMusicSkippAllSkippedAllMusic=Skipped all music!
 
 CommandMusicVolumeChangedSuccess=The volume has been set to {1}%%!
 
 CommandMusicListNoList=The bot has no playlist right now. Add some with {1}!
-CommandMusicListCurrentTrack=Current Track : `{1}`
+CommandMusicListCurrentTrack=Current Track : {1}
 CommandMusicListHeader=Here's the current playlist!
-CommandMusicListTrackInfo=Track number `{1}` : `{2}`.
+CommandMusicListTrackInfo=Track number {1} : {2}.
 
 CommandMusicDisconnectNotConnected=The bot is not even connected!
 CommandMusicDisconnectSuccess=The bot successfully disconnected!
@@ -98,11 +98,11 @@ CommandMusicLoopNotPlaying=You cannot loop music when the bot is not playing!
 NumberNotANumber=Please use a number!
 NumberNotBetweenRange=Please enter a number between {1} and {2}.
 
-MusicManagerTrackLoaded=`{1}` has been added.
-MusicManagerPlaylistLoaded=Playlist `{1}` has been added :
-MusicManagerPlaylistAddedTrackInfo=Added track `#{1}` **->** `{2}`.
-MusicManagerNoMatch=The song `{1}` has not been found.
-MusicManagerLoadFailed=Cannot load the song : `{1}`.
+MusicManagerTrackLoaded={1} has been added.
+MusicManagerPlaylistLoaded=Playlist {1} has been added :
+MusicManagerPlaylistAddedTrackInfo=Added track `#{1}` **->** {2}.
+MusicManagerNoMatch=The song {1} has not been found.
+MusicManagerLoadFailed=Cannot load the song : {1}.
 
 StringTest=Hello!
 TestingReplacements=Hello {1}!

--- a/res/lang/strings_fr_CA.properties
+++ b/res/lang/strings_fr_CA.properties
@@ -1,64 +1,64 @@
-LanguageName=Français
+LanguageName=FranÃ§ais
 
 Usage=Utilisation
 
-NoActionForCommand=*Aucune action créée pour la commande* %1$s *- faites une idée dans la chaîne de texte __ideas__!*
+NoActionForCommand=*Aucune action crÃ©Ã©e pour la commande* {1} *- faites une idÃ©e dans la chaÃ®ne de texte __ideas__!*
 TERMINATE=
-CommandIsRunningError=Impossible d'exécuter une autre instance de la commande `%1$s`: elle est déjà en cours d'exécution.
-HelloResponse=Bonjour %1$s!
-MessageReceivedFromPrivateResponse=Vous devez être dans un serveur pour interagir avec moi!
+CommandIsRunningError=Impossible d'exÃ©cuter une autre instance de la commande {1} : elle est dÃ©jÃ  en cours d'exÃ©cution.
+HelloResponse=Bonjour {1}!
+MessageReceivedFromPrivateResponse=Vous devez Ãªtre dans un serveur pour interagir avec moi!
 MessageIsOnlyPrefixResponse=... vous vouliez me parler ou ...?
 
-CommandUserHasNoPrivateChannel=L'utilisateur n'a pas de chaîne privée, annulation.
-CommandCannotDisconnectOrNotConnected=Le bot ne peut pas être déconnecté s'il ne se trouve pas dans un canal vocal.
-CommandDisconnectDisconnected=Le bot a été déconnecté
+CommandUserHasNoPrivateChannel=L'utilisateur n'a pas de chaÃ®ne privÃ©e, annulation.
+CommandCannotDisconnectOrNotConnected=Le bot ne peut pas Ãªtre dÃ©connectÃ© s'il ne se trouve pas dans un canal vocal.
+CommandDisconnectDisconnected=Le bot a Ã©tÃ© dÃ©connectÃ©
 
-CommandLanguageChangingLanguage=La langue a été définie sur: `%1$s`!
-CommandLanguageNoTranslation=Le bot n'a pas été traduit dans cette langue!
-CommandLanguageNullContent=Utilisation : %1$s OU %2$s.
+CommandLanguageChangingLanguage=La langue a Ã©tÃ© dÃ©finie sur: {1}!
+CommandLanguageNoTranslation=Le bot n'a pas Ã©tÃ© traduit dans cette langue!
+CommandLanguageNullContent=Utilisation : {1} OU {2}.
 CommandLanguageNullContentUsage=nom de la langue
 
-CommandClearConfirmMessage=Êtes-vous sûr de vouloir effacer tous les messages?
+CommandClearConfirmMessage=ÃŠtes-vous sÃ»r de vouloir effacer tous les messages?
 CommandClearNoPermission=Je n'ai pas les permissions pour cela!
-CommandClearCannotBulkDeleteOld=Un ou plusieurs messages n'ont pas pu être supprimés. Le message de suppression en bloc ne peut pas dépasser 2 semaines. Veuillez réessayer plus tôt.
+CommandClearCannotBulkDeleteOld=Un ou plusieurs messages n'ont pas pu Ãªtre supprimÃ©s. Le message de suppression en bloc ne peut pas dÃ©passer 2 semaines. Veuillez rÃ©essayer plus tÃ´t.
 
-CommandHelpContent=L'aide est là
-CommandHelpHelpSentMessage=*Aide envoyée!*
+CommandHelpContent=L'aide est lÃ 
+CommandHelpHelpSentMessage=*Aide envoyÃ©e!*
 
-CommandStopSavedFromSpam=Vous avez été sauvé du spam %1$s
-CommandStopNoCommandToStopMessage=Aucune commande avec le nom `%1$s` n'a été trouvée, aucune action n'a été prise.
-CommandStopCommandFullyStoppedMessage=La commande `%1$s` a été arrêtée avec succès. %1$s
-CommandStopCommandNotStoppedMessage=La commande `%1$s` a refusée de s'arrêter. Ooo, effrayant. (*Il n'a simplement probablement pas été mis en \u0153uvre...*)
-CommandStopBotCantStop=JE NE PEUX PAS ARRÊTER
+CommandStopSavedFromSpam=Vous avez Ã©tÃ© sauvÃ© du spam {1}
+CommandStopNoCommandToStopMessage=Aucune commande avec le nom `{1}` n'a Ã©tÃ© trouvÃ©e, aucune action n'a Ã©tÃ© prise.
+CommandStopCommandFullyStoppedMessage=La commande `{1}` a Ã©tÃ© arrÃªtÃ©e avec succÃ¨s. {1}
+CommandStopCommandNotStoppedMessage=La commande `{1}` a refusÃ©e de s'arrÃªter. Ooo, effrayant. (*Il n'a simplement probablement pas Ã©tÃ© mis en \u0153uvre...*)
+CommandStopBotCantStop=JE NE PEUX PAS ARRÃŠTER
 
 CommandSpamSpam=Spam
-CommandSpamUsageStart=`%1$s`
-CommandSpamUsageFirstLine=Envoi par défaut %1$s messages de spam.
+CommandSpamUsageStart=`{1}`
+CommandSpamUsageFirstLine=Envoi par dÃ©faut {1} messages de spam.
 CommandSpamUsageSecondLine=Envoie un **[nombre de spam]**.
-CommandSpamUsageThirdLine=Envoie un **[nombre de spam]** avec un **[message personnalisé]**.
+CommandSpamUsageThirdLine=Envoie un **[nombre de spam]** avec un **[message personnalisÃ©]**.
 
-GameInteractionCommandGamesReadyToBeRolledMessage=Les jeux suivants sont maintenant prêts à être roulés :
-GameInteractionCommandInitialViewListAgainMessage=Entrez la commande %s pour afficher cette liste à nouveau.
-GameInteractionCommandAddedGameSuccessMessage=Le jeu `%1$s` a été ajouté à la liste! \"
-GameInteractionCommandAddErrorNoPoolCreated=Votre liste de jeux n'a pas encore été créé. Vous pouvez créer une liste de jeux en utilisant %s.
-GameInteractionCommandRemovedGameSuccessMessage=Le jeu `%s` a été supprimé de la liste de jeux!
-GameInteractionCommandRemoveErrorNoSuchGame=Ce jeu n'est pas présent dans votre liste! Tapez %s pour voir les jeux que vous avez dans votre liste.
+GameInteractionCommandGamesReadyToBeRolledMessage=Les jeux suivants sont maintenant prÃªts Ã  Ãªtre roulÃ©s :
+GameInteractionCommandInitialViewListAgainMessage=Entrez la commande %s pour afficher cette liste Ã  nouveau.
+GameInteractionCommandAddedGameSuccessMessage=Le jeu `{1}` a Ã©tÃ© ajoutÃ© Ã  la liste! \"
+GameInteractionCommandAddErrorNoPoolCreated=Votre liste de jeux n'a pas encore Ã©tÃ© crÃ©Ã©. Vous pouvez crÃ©er une liste de jeux en utilisant %s.
+GameInteractionCommandRemovedGameSuccessMessage=Le jeu `%s` a Ã©tÃ© supprimÃ© de la liste de jeux!
+GameInteractionCommandRemoveErrorNoSuchGame=Ce jeu n'est pas prÃ©sent dans votre liste! Tapez %s pour voir les jeux que vous avez dans votre liste.
 GameInteractionCommandRemoveIsNowEmpty=La liste de jeux est maintenant vide!
 GameInteractionCommandRemoveErrorEmptyPool=Vous ne pouvez pas supprimer un jeu d'une liste de jeux vide!
-GameInteractionCommandRollNumberIsNotValid=Le nombre entré doit être un nombre positif.
+GameInteractionCommandRollNumberIsNotValid=Le nombre entrÃ© doit Ãªtre un nombre positif.
 GameInteractionCommandRolledGameMessage=Vous allez jouer: `%s`!
-GameInteractionCommandRolledMultipleGamesMessage=Le %s jeu sélectionné est: `%s`.
-GameInteractionCommandRollErrorPoolEmpty=La liste de jeux est vide! Créez une liste de jeux en utilisant %s!
-GameInteractionCommandRollErrorUsageMessage=Utilisation:\n%s OU %s: lancez les dés une fois pour obtenir un jeu aléatoire.\n%s OU %s: lance un jeu aléatoire pour le nombre de temps saisi.
+GameInteractionCommandRolledMultipleGamesMessage=Le %s jeu sÃ©lectionnÃ© est: `%s`.
+GameInteractionCommandRollErrorPoolEmpty=La liste de jeux est vide! CrÃ©ez une liste de jeux en utilisant %s!
+GameInteractionCommandRollErrorUsageMessage=Utilisation:\n%s OU %s: lancez les dÃ©s une fois pour obtenir un jeu alÃ©atoire.\n%s OU %s: lance un jeu alÃ©atoire pour le nombre de temps saisi.
 GameInteractionCommandListNoGamesInPoolMessage=Pas de jeux dans votre liste!
 GameInteractionCommandListTitleOfList=Voici les jeux dans votre liste de jeux :
-GameInteractionCommandErrorInitialUsage=Utilisation: %s.\nSéparez les jeux en utilisant des virgules.
+GameInteractionCommandErrorInitialUsage=Utilisation: %s.\nSÃ©parez les jeux en utilisant des virgules.
 GameInteractionCommandErrorAddUsage=Utilisation : %s.
-GameInteractionCommandErrorRemoveUsage=Utilisation: %s.\nVous pouvez également entrer %s pour supprimer tous les jeux dans le pool actuel.
-GameInteractionCommandErrorUndefined=Une erreur insoupçonnée s'est produite. Qu'avez-vous fait.
+GameInteractionCommandErrorRemoveUsage=Utilisation: %s.\nVous pouvez Ã©galement entrer %s pour supprimer tous les jeux dans le pool actuel.
+GameInteractionCommandErrorUndefined=Une erreur insoupÃ§onnÃ©e s'est produite. Qu'avez-vous fait.
 
-CommandConfirmedCustomAndConfirmMessage=Entrez %s pour confirmer. Entrer %s annule la confirmation. Toute autre commande annule la confirmation et exécute la commande entrée.
-CommandConfirmedConfCancelled=Confirmation annulée
+CommandConfirmedCustomAndConfirmMessage=Entrez %s pour confirmer. Entrer %s annule la confirmation. Toute autre commande annule la confirmation et exÃ©cute la commande entrÃ©e.
+CommandConfirmedConfCancelled=Confirmation annulÃ©e
 
 StringTest=Salut!
 TestingReplacements=Bonjour %s!

--- a/res/lang/strings_fr_CA.properties
+++ b/res/lang/strings_fr_CA.properties
@@ -26,9 +26,9 @@ CommandHelpContent=L'aide est là
 CommandHelpHelpSentMessage=*Aide envoyée!*
 
 CommandStopSavedFromSpam=Vous avez été sauvé du spam {1}
-CommandStopNoCommandToStopMessage=Aucune commande avec le nom `{1}` n'a été trouvée, aucune action n'a été prise.
-CommandStopCommandFullyStoppedMessage=La commande `{1}` a été arrêtée avec succès. {1}
-CommandStopCommandNotStoppedMessage=La commande `{1}` a refusée de s'arrêter. Ooo, effrayant. (*Il n'a simplement probablement pas été mis en \u0153uvre...*)
+CommandStopNoCommandToStopMessage=Aucune commande avec le nom {1} n'a été trouvée, aucune action n'a été prise.
+CommandStopCommandFullyStoppedMessage=La commande {1} a été arrêtée avec succès. {1}
+CommandStopCommandNotStoppedMessage=La commande {1} a refusée de s'arrêter. Ooo, effrayant. (*Il n'a simplement probablement pas été mis en \u0153uvre...*)
 CommandStopBotCantStop=JE NE PEUX PAS ARRÊTER
 
 CommandSpamSpam=Spam
@@ -39,26 +39,26 @@ CommandSpamUsageThirdLine=Envoie un **[nombre de spam]** avec un **[message pers
 
 GameInteractionCommandGamesReadyToBeRolledMessage=Les jeux suivants sont maintenant prêts à être roulés :
 GameInteractionCommandInitialViewListAgainMessage=Entrez la commande %s pour afficher cette liste à nouveau.
-GameInteractionCommandAddedGameSuccessMessage=Le jeu `{1}` a été ajouté à la liste! \"
+GameInteractionCommandAddedGameSuccessMessage=Le jeu {1} a été ajouté à la liste!
 GameInteractionCommandAddErrorNoPoolCreated=Votre liste de jeux n'a pas encore été créé. Vous pouvez créer une liste de jeux en utilisant %s.
-GameInteractionCommandRemovedGameSuccessMessage=Le jeu `%s` a été supprimé de la liste de jeux!
-GameInteractionCommandRemoveErrorNoSuchGame=Ce jeu n'est pas présent dans votre liste! Tapez %s pour voir les jeux que vous avez dans votre liste.
+GameInteractionCommandRemovedGameSuccessMessage=Le jeu {1} a été supprimé de la liste de jeux!
+GameInteractionCommandRemoveErrorNoSuchGame=Ce jeu n'est pas présent dans votre liste! Tapez {1} pour voir les jeux que vous avez dans votre liste.
 GameInteractionCommandRemoveIsNowEmpty=La liste de jeux est maintenant vide!
 GameInteractionCommandRemoveErrorEmptyPool=Vous ne pouvez pas supprimer un jeu d'une liste de jeux vide!
 GameInteractionCommandRollNumberIsNotValid=Le nombre entré doit être un nombre positif.
-GameInteractionCommandRolledGameMessage=Vous allez jouer: `%s`!
-GameInteractionCommandRolledMultipleGamesMessage=Le %s jeu sélectionné est: `%s`.
-GameInteractionCommandRollErrorPoolEmpty=La liste de jeux est vide! Créez une liste de jeux en utilisant %s!
-GameInteractionCommandRollErrorUsageMessage=Utilisation:\n%s OU %s: lancez les dés une fois pour obtenir un jeu aléatoire.\n%s OU %s: lance un jeu aléatoire pour le nombre de temps saisi.
+GameInteractionCommandRolledGameMessage=Vous allez jouer: {1}!
+GameInteractionCommandRolledMultipleGamesMessage=Le {1} jeu sélectionné est: {2}.
+GameInteractionCommandRollErrorPoolEmpty=La liste de jeux est vide! Créez une liste de jeux en utilisant {1}!
+GameInteractionCommandRollErrorUsageMessage=Utilisation:\n{1} OU {2}: lancez les dés une fois pour obtenir un jeu aléatoire.\n{3} OU {4}: lance un jeu aléatoire pour le nombre de temps saisi.
 GameInteractionCommandListNoGamesInPoolMessage=Pas de jeux dans votre liste!
 GameInteractionCommandListTitleOfList=Voici les jeux dans votre liste de jeux :
-GameInteractionCommandErrorInitialUsage=Utilisation: %s.\nSéparez les jeux en utilisant des virgules.
-GameInteractionCommandErrorAddUsage=Utilisation : %s.
-GameInteractionCommandErrorRemoveUsage=Utilisation: %s.\nVous pouvez également entrer %s pour supprimer tous les jeux dans le pool actuel.
+GameInteractionCommandErrorInitialUsage=Utilisation: {1}.\nSéparez les jeux en utilisant des virgules.
+GameInteractionCommandErrorAddUsage=Utilisation : {1}.
+GameInteractionCommandErrorRemoveUsage=Utilisation: {1}.\nVous pouvez également entrer {2} pour supprimer tous les jeux dans le pool actuel.
 GameInteractionCommandErrorUndefined=Une erreur insoupçonnée s'est produite. Qu'avez-vous fait.
 
-CommandConfirmedCustomAndConfirmMessage=Entrez %s pour confirmer. Entrer %s annule la confirmation. Toute autre commande annule la confirmation et exécute la commande entrée.
+CommandConfirmedCustomAndConfirmMessage=Entrez {1} pour confirmer. Entrer {2} annule la confirmation. Toute autre commande annule la confirmation et exécute la commande entrée.
 CommandConfirmedConfCancelled=Confirmation annulée
 
 StringTest=Salut!
-TestingReplacements=Bonjour %s!
+TestingReplacements=Bonjour {1}!

--- a/res/lang/strings_fr_CA.properties
+++ b/res/lang/strings_fr_CA.properties
@@ -23,7 +23,7 @@ CommandClearNoPermission=Je n'ai pas les permissions pour cela!
 CommandClearCannotBulkDeleteOld=Un ou plusieurs messages n'ont pas pu être supprimés. Le message de suppression en bloc ne peut pas dépasser 2 semaines. Veuillez réessayer plus tôt.
 
 CommandHelpContent=L'aide est là
-CommandHelpHelpSentMessage=*Aide envoyée!*
+CommandHelpHelpSentMessage=Aide envoyée!
 
 CommandStopSavedFromSpam=Vous avez été sauvé du spam {1}
 CommandStopNoCommandToStopMessage=Aucune commande avec le nom {1} n'a été trouvée, aucune action n'a été prise.
@@ -32,7 +32,7 @@ CommandStopCommandNotStoppedMessage=La commande {1} a refusée de s'arrêter. Oo
 CommandStopBotCantStop=JE NE PEUX PAS ARRÊTER
 
 CommandSpamSpam=Spam
-CommandSpamUsageStart=`{1}`
+CommandSpamUsageStart={1}
 CommandSpamUsageFirstLine=Envoi par défaut {1} messages de spam.
 CommandSpamUsageSecondLine=Envoie un **[nombre de spam]**.
 CommandSpamUsageThirdLine=Envoie un **[nombre de spam]** avec un **[message personnalisé]**.

--- a/src/app/CommandRouter.java
+++ b/src/app/CommandRouter.java
@@ -98,7 +98,7 @@ public class CommandRouter extends AbstractCommandRouter implements Resources,
 								eventDigger, this)){
 							
 							setCommand(new BotError(lang(
-									"CommandIsRunningError", commandName)));
+									"CommandIsRunningError", code(commandName))));
 							
 						}
 						else{

--- a/src/commands/CommandGameAdd.java
+++ b/src/commands/CommandGameAdd.java
@@ -21,7 +21,7 @@ public class CommandGameAdd extends GameInteractionCommands {
 				
 				gamepool.add(getContent());
 				
-				sendMessage(lang("AddedGameSuccessMessage", getContent()));
+				sendMessage(lang("AddedGameSuccessMessage", code(getContent())));
 				
 			}
 			catch(NullPointerException e){

--- a/src/commands/CommandGameRemove.java
+++ b/src/commands/CommandGameRemove.java
@@ -32,7 +32,7 @@ public class CommandGameRemove extends GameInteractionCommands {
 					
 					if(gamepool.remove(getContent()))
 						sendMessage(lang("RemovedGameSuccessMessage",
-								getContent()));
+								code(getContent())));
 					else
 						new BotError(this, lang("ErrorNoSuchGame",
 								buildVCommand(GAME_LIST)));
@@ -59,9 +59,9 @@ public class CommandGameRemove extends GameInteractionCommands {
 	public Object getCalls(){
 		return GAME_REMOVE;
 	}
-
+	
 	@Override
-	public String getCommandDescription() {
+	public String getCommandDescription(){
 		return "Remove a game form the game list";
 	}
 }

--- a/src/commands/CommandGameRoll.java
+++ b/src/commands/CommandGameRoll.java
@@ -1,10 +1,10 @@
 package commands;
 
-import java.util.Random;
-
+import errorHandling.BotError;
 import utilities.abstracts.GameInteractionCommands;
 import utilities.specifics.GamePool;
-import errorHandling.BotError;
+
+import java.util.Random;
 
 public class CommandGameRoll extends GameInteractionCommands {
 	
@@ -32,7 +32,7 @@ public class CommandGameRoll extends GameInteractionCommands {
 				
 				num = ran.nextInt(gamepool.size());
 				
-				sendMessage(lang("RolledGameMessage", gamepool.get(num)));
+				sendMessage(lang("RolledGameMessage", code(gamepool.get(num))));
 				
 			}
 			else{
@@ -42,7 +42,7 @@ public class CommandGameRoll extends GameInteractionCommands {
 					num = ran.nextInt(gamepool.size());
 					
 					sendMessage(lang("RolledMultipleGamesMessage", i,
-							gamepool.get(num)));
+							code(gamepool.get(num))));
 					
 				}
 				
@@ -72,9 +72,9 @@ public class CommandGameRoll extends GameInteractionCommands {
 			GAME_ROLL, GAME_ROLL_ALT
 		};
 	}
-
+	
 	@Override
-	public String getCommandDescription() {
+	public String getCommandDescription(){
 		return "Use this command tu select a random game from your list when you don't know what to play.";
 	}
 }

--- a/src/commands/CommandHelp.java
+++ b/src/commands/CommandHelp.java
@@ -29,7 +29,7 @@ public class CommandHelp extends BotCommand {
 			
 			if(hasParameter("p")){
 				sendPrivateMessage(fullHelpString);
-				sendInfoMessage(lang("HelpSentMessage"));
+				sendInfoMessage(ital(lang("HelpSentMessage")));
 			}
 			else{
 				sendMessage(fullHelpString);

--- a/src/commands/CommandLanguage.java
+++ b/src/commands/CommandLanguage.java
@@ -35,8 +35,8 @@ public class CommandLanguage extends BotCommand {
 				
 				remember(changedDictionary, BUFFER_LANG);
 				
-				sendInfoMessage(String.format(langChangeMessage,
-						changedDictionary.getDirectString("LanguageName")));
+				sendInfoMessage(format(langChangeMessage,
+						code(changedDictionary.getDirectString("LanguageName"))));
 				
 			}
 			

--- a/src/commands/CommandMusicList.java
+++ b/src/commands/CommandMusicList.java
@@ -23,10 +23,9 @@ public class CommandMusicList extends MusicCommands {
 			AudioTrack currentTrack = MusicManager.get().getPlayer(this)
 					.getAudioPlayer().getPlayingTrack();
 			
-			sb.append(lang("CurrentTrack", currentTrack.getInfo().title));
+			sb.append(lang("CurrentTrack", code(currentTrack.getInfo().title)));
 			
-			if(MusicManager.get().getPlayer(this).getListener()
-					.getTrackSize() != 0){
+			if(MusicManager.get().getPlayer(this).getListener().getTrackSize() != 0){
 				
 				sb.append("\n\n").append(lang("Header")).append("\n\n");
 				
@@ -35,8 +34,9 @@ public class CommandMusicList extends MusicCommands {
 				for(AudioTrack track : MusicManager.get().getPlayer(this)
 						.getListener().getTracks()){
 					
-					sb.append(lang("TrackInfo", i++, track.getInfo().title))
-							.append("\n");
+					sb.append(
+							lang("TrackInfo", code(i++),
+									code(track.getInfo().title))).append("\n");
 					
 				}
 				
@@ -52,10 +52,10 @@ public class CommandMusicList extends MusicCommands {
 	public Object getCalls(){
 		return MUSIC_LIST;
 	}
-
+	
 	@Override
-	public String getCommandDescription() {
+	public String getCommandDescription(){
 		return "Display a list of all the music that you have in the music list";
-
+		
 	}
 }

--- a/src/commands/CommandMusicSkip.java
+++ b/src/commands/CommandMusicSkip.java
@@ -32,13 +32,14 @@ public class CommandMusicSkip extends MusicCommands {
 						new BotError(this, lang("NotPlaying"));
 					}
 					else{
-						if (this.hasMemory("MUSIC_LOOP") && (boolean) this.getMemory("MUSIC_LOOP")) {
+						if(this.hasMemory("MUSIC_LOOP")
+								&& (boolean)this.getMemory("MUSIC_LOOP")){
 							forget("MUSIC_LOOP");
 						}
 						if(player.skipTrack()){
-							sendInfoMessage(lang("SkippedNowPlaying", player
-									.getAudioPlayer().getPlayingTrack()
-									.getInfo().title));
+							sendInfoMessage(lang("SkippedNowPlaying",
+									code(player.getAudioPlayer()
+											.getPlayingTrack().getInfo().title)));
 						}
 						else{
 							sendInfoMessage(lang("NoMoreMusic"));
@@ -77,9 +78,10 @@ public class CommandMusicSkip extends MusicCommands {
 								new CommandConfirmed(this){
 									@Override
 									public String getConfMessage(){
-										return lang("OverflowConfirm",
-												skipAmount,
-												player.getNumberOfTracks());
+										return lang(
+												"OverflowConfirm",
+												code(skipAmount),
+												code(player.getNumberOfTracks()));
 									}
 									
 									@Override
@@ -115,9 +117,9 @@ public class CommandMusicSkip extends MusicCommands {
 	public Object getCalls(){
 		return MUSIC_SKIP;
 	}
-
+	
 	@Override
-	public String getCommandDescription() {
+	public String getCommandDescription(){
 		return "Skip the song that is currently playing";
 	}
 }

--- a/src/commands/CommandSpam.java
+++ b/src/commands/CommandSpam.java
@@ -57,12 +57,14 @@ public class CommandSpam extends BotCommand {
 			String commandStart = lang("UsageStart");
 			String command = buildCommand(SPAM);
 			
-			String command1 = String.format(commandStart, command) + " : "
-					+ String.format(lang("UsageFirstLine"), numberOfSpam);
-			String command2 = String.format(commandStart, command
+			String command1 = format(commandStart, command) + " : "
+					+ format(lang("UsageFirstLine"), numberOfSpam);
+			
+			String command2 = format(commandStart, command
 					+ " [number of times to spam]")
 					+ " : " + lang("UsageSecondLine");
-			String command3 = String.format(commandStart, command
+			
+			String command3 = format(commandStart, command
 					+ " [number of times to spam] [custom message]")
 					+ " : " + lang("UsageThirdLine");
 			

--- a/src/commands/CommandStop.java
+++ b/src/commands/CommandStop.java
@@ -51,7 +51,8 @@ public class CommandStop extends BotCommand {
 							getRouter());
 			
 			if(commandToStop == null){
-				new BotError(this, lang("NoCommandToStopMessage", getContent()));
+				new BotError(this, lang("NoCommandToStopMessage",
+						code(getContent())));
 			}
 			else{
 				stopCommandLogic(commandToStop);
@@ -65,10 +66,10 @@ public class CommandStop extends BotCommand {
 		
 		if(commandToStop.stopAction())
 			sendInfoMessage(lang("CommandFullyStoppedMessage",
-					commandToStop.getCommandName(), EMOJI_OK_HAND));
+					code(commandToStop.getCommandName()), EMOJI_OK_HAND));
 		else{
 			new BotError(this, lang("CommandNotStoppedMessage",
-					commandToStop.getCommandName()), true);
+					code(commandToStop.getCommandName())), true);
 		}
 		
 	}

--- a/src/utilities/music/MusicManager.java
+++ b/src/utilities/music/MusicManager.java
@@ -1,11 +1,5 @@
 package utilities.music;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import utilities.BotCommand;
-import net.dv8tion.jda.core.entities.Guild;
-
 import com.sedmelluq.discord.lavaplayer.player.AudioLoadResultHandler;
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
@@ -13,6 +7,11 @@ import com.sedmelluq.discord.lavaplayer.source.AudioSourceManagers;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
+import net.dv8tion.jda.core.entities.Guild;
+import utilities.BotCommand;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class MusicManager {
 	
@@ -82,7 +81,7 @@ public class MusicManager {
 			@Override
 			public void trackLoaded(AudioTrack track){
 				command.sendMessage(command.lang("MusicManagerTrackLoaded",
-						track.getInfo().title));
+						command.code(track.getInfo().title)));
 				
 				player.playTrack(track);
 			}
@@ -94,14 +93,15 @@ public class MusicManager {
 				
 				builder.append(
 						command.lang("MusicManagerPlaylistLoaded",
-								playlist.getName())).append("\n");
+								command.code(playlist.getName()))).append("\n");
 				
 				for(int i = 0; i < playlist.getTracks().size(); i++){
 					AudioTrack track = playlist.getTracks().get(i);
 					
 					builder.append("\n").append(
 							command.lang("MusicManagerPlaylistAddedTrackInfo",
-									(i + 1), track.getInfo().title));
+									(i + 1),
+									command.code(track.getInfo().title)));
 					
 					player.playTrack(track);
 				}
@@ -112,13 +112,14 @@ public class MusicManager {
 			
 			@Override
 			public void noMatches(){
-				command.sendMessage(command.lang("MusicManagerNoMatch", source));
+				command.sendMessage(command.lang("MusicManagerNoMatch",
+						command.code(source)));
 			}
 			
 			@Override
 			public void loadFailed(FriendlyException exeption){
 				command.sendMessage(command.lang("MusicManagerLoadFailed",
-						exeption.getMessage()));
+						command.code(exeption.getMessage())));
 			}
 			
 		});


### PR DESCRIPTION
**DO NOT MERGE YET** : I will convert the previous lang files in this PR before merging this feature. Technically speaking, I don't have too as everything will still work the way it was before, but it'll be better if there's a proof of concept attached to this PR.

---

This PR adds the ability to format the lang lines with variables :

**Before**
```
CommandLanguageNullContent=Usage : %1$s OR %2$s.
```

**After**
```
CommandLanguageNullContent=Usage : {1} OR {2}.
```

To protect a wanted `{#}` in a lang line, simple add a `^` after the first bracket : 
```
CommandLanguageNullContent=Usage : {1}{^2}.
```
that line will then return a well formatted `Usage : %1$s{2}.`, which when replaced (_example with `banana`_) will return : `Usage : banana{2}.`

Closes #86