### PR TITLE
Add content-less parameters handling

### DIFF
--- a/framework/vendor/objects/ParametersHelp.java
+++ b/framework/vendor/objects/ParametersHelp.java
@@ -5,13 +5,20 @@ import java.util.ArrayList;
 public class ParametersHelp {
 	
 	private String parameterDescription;
+	private boolean acceptsContent;
 	private String param;
 	private String[] paramVariants;
 	
 	public ParametersHelp(String parameterDescription, String param,
 			String... paramVariants){
+		this(parameterDescription, true, param, paramVariants);
+	}
+	
+	public ParametersHelp(String parameterDescription, boolean acceptsContent, String param,
+			String... paramVariants){
 		
 		this.parameterDescription = parameterDescription;
+		this.acceptsContent = acceptsContent;
 		this.param = param;
 		this.paramVariants = paramVariants;
 		
@@ -19,6 +26,10 @@ public class ParametersHelp {
 	
 	public String getParameterDescription(){
 		return this.parameterDescription;
+	}
+	
+	public boolean doesAcceptsContent(){
+		return this.acceptsContent;
 	}
 	
 	public String getParam(){

--- a/framework/vendor/objects/Request.java
+++ b/framework/vendor/objects/Request.java
@@ -567,7 +567,10 @@ public class Request extends Translatable implements Utils {
 		}
 		else{
 			
-			setContent(getContent() + " " + paramFound.getContent());
+			if(getContent() == null)
+				setContent(paramFound.getContent());
+			else
+				setContent(getContent() + " " + paramFound.getContent());
 			
 			paramFound.setAcceptingContent(false);
 			

--- a/framework/vendor/objects/Request.java
+++ b/framework/vendor/objects/Request.java
@@ -198,7 +198,8 @@ public class Request extends Translatable implements Utils {
 				int paramStartPos = -1;
 				int paramEndPos = -1;
 				
-				if(possibleParam.equals(getParametersPrefix() + "" + getParametersPrefix())){
+				if(possibleParam.equals(getParametersPrefix() + ""
+						+ getParametersPrefix())){
 					// If string is double parameter prefix, remove it and stop taking params
 					
 					paramStartPos = getContent().indexOf(possibleParam);
@@ -267,7 +268,8 @@ public class Request extends Translatable implements Utils {
 						
 						for(int j = 0; j < singleParams.length && canRoll; j++){
 							
-							Parameter newParam = new Parameter(singleParams[j], i + j);
+							Parameter newParam = new Parameter(singleParams[j],
+									i + j);
 							
 							if(parameters.containsValue(newParam)){
 								
@@ -563,7 +565,8 @@ public class Request extends Translatable implements Utils {
 		Parameter paramFound = getParameter(paramName);
 		
 		if(paramFound == null){
-			throw new NullPointerException("Parameter \"" + paramName + "\"is not present or linked in this request.");
+			throw new NullPointerException("Parameter \"" + paramName
+					+ "\"is not present or linked in this request.");
 		}
 		else{
 			
@@ -577,7 +580,8 @@ public class Request extends Translatable implements Utils {
 		}
 	}
 	
-	public void setParamsAsContentLess(ArrayList<String> paramsToTreatAsContentLess){
+	public void setParamsAsContentLess(
+			ArrayList<String> paramsToTreatAsContentLess){
 		
 		for(String paramName : paramsToTreatAsContentLess){
 			try{

--- a/framework/vendor/objects/Request.java
+++ b/framework/vendor/objects/Request.java
@@ -18,10 +18,15 @@ public class Request extends Translatable implements Utils {
 		private String parameterContent;
 		
 		private int position;
+		private boolean acceptsContent;
 		
-		protected Parameter(){}
+		protected Parameter(){
+			this.acceptsContent = true;
+		}
 		
 		public Parameter(String parameter){
+			this();
+			
 			if(parameter.matches(getParametersPrefixProtected() + "{1,2}.+")){
 				
 				int paramDeclaratorLength = parameter
@@ -66,7 +71,10 @@ public class Request extends Translatable implements Utils {
 		}
 		
 		protected void setContent(String parameterContent){
-			this.parameterContent = parameterContent.replaceAll("\"", "");
+			if(parameterContent == null)
+				this.parameterContent = null;
+			else
+				this.parameterContent = parameterContent.replaceAll("\"", "");
 		}
 		
 		public int getPosition(){
@@ -75,6 +83,18 @@ public class Request extends Translatable implements Utils {
 		
 		protected void setPosition(int position){
 			this.position = position;
+		}
+		
+		public boolean doesAcceptContent(){
+			return this.acceptsContent;
+		}
+		
+		protected void setAcceptingContent(boolean acceptsContent){
+			this.acceptsContent = acceptsContent;
+			
+			if(!acceptsContent && getContent() != null){
+				setContent(null);
+			}
 		}
 		
 		@Override
@@ -536,6 +556,32 @@ public class Request extends Translatable implements Utils {
 				}
 				
 			});
+		
+	}
+	
+	protected void setParameterContentLess(String paramName){
+		Parameter paramFound = getParameter(paramName);
+		
+		if(paramFound == null){
+			throw new NullPointerException("Parameter \"" + paramName + "\"is not present or linked in this request.");
+		}
+		else{
+			
+			setContent(getContent() + " " + paramFound.getContent());
+			
+			paramFound.setAcceptingContent(false);
+			
+		}
+	}
+	
+	public void setParamsAsContentLess(ArrayList<String> paramsToTreatAsContentLess){
+		
+		for(String paramName : paramsToTreatAsContentLess){
+			try{
+				this.setParameterContentLess(paramName);
+			}
+			catch(NullPointerException e){}
+		}
 		
 	}
 	

--- a/src/app/CommandRouter.java
+++ b/src/app/CommandRouter.java
@@ -118,12 +118,20 @@ public class CommandRouter extends AbstractCommandRouter implements Resources,
 					
 					if(commandParamsHelp != null){
 						ArrayList<ArrayList<String>> paramsHelpMap = new ArrayList<>();
+						ArrayList<String> contentLessParams = new ArrayList<>();
 						
 						for(ParametersHelp commandParamHelp : commandParamsHelp){
+							
 							paramsHelpMap.add(commandParamHelp.getAllParams());
+							
+							if(!commandParamHelp.doesAcceptsContent()){
+								contentLessParams.add(commandParamHelp.getParam());
+							}
+							
 						}
 						
 						getRequest().setParamLinkMap(paramsHelpMap);
+						getRequest().setParamsAsContentLess(contentLessParams);
 					}
 					
 				}


### PR DESCRIPTION
I added a constructor for `ParameterHelp` that allows setting a particular Parameter as "content-less" : a state where the parameter does not accept content and instead sends it to the content of the command.

> Basically, this would go in [`setParamLinkMap`](https://github.com/Vhoyon/Discord-Bot/blob/8e033066f8d2d6b5ee74803ed6289b75c6070088/framework/vendor/objects/Request.java#L484-L487) of the Request object.

Although I talked about adding this functionnality to the  `setParamLinkMap` method, I actually created a new method because even though these two are linked in our bot, a request coming from another source might implement a solution for content-less params while not providing a map to link different param calls.

Closes #116