### PR TITLE
Remove Request's Translatable references throughout application

### DIFF
--- a/framework/vendor/abstracts/AbstractCommandRouter.java
+++ b/framework/vendor/abstracts/AbstractCommandRouter.java
@@ -51,12 +51,11 @@ public abstract class AbstractCommandRouter extends Thread implements Utils,
 		
 		this.commandsRepo = commandsRepo;
 		
-		this.request = createRequest(receivedMessage, getDictionary());
+		this.request = createRequest(receivedMessage);
 		
 	}
 	
-	protected abstract Request createRequest(String receivedMessage,
-			Dictionary dict);
+	protected abstract Request createRequest(String receivedMessage);
 	
 	public Command getCommand(){
 		return this.command;

--- a/framework/vendor/lang/strings_en_US.properties
+++ b/framework/vendor/lang/strings_en_US.properties
@@ -1,6 +1,0 @@
-RequestParamStartSingle=That parameter
-RequestParamStartMultiple=Those parameters
-RequestParamStartFollowing=has been entered more than once :
-RequestEndMessage=Only the first instance of %1$s will be taken into consideration.
-RequestEndMessageSingle=the parameter
-RequestEndMessageMultiple=those parameters

--- a/framework/vendor/lang/strings_fr_CA.properties
+++ b/framework/vendor/lang/strings_fr_CA.properties
@@ -1,6 +1,0 @@
-RequestParamStartSingle=Ce paramètre
-RequestParamStartMultiple=Ces paramètres
-RequestParamStartFollowing=a été saisi plus d'une fois :
-RequestEndMessage=Seule la première instance de %1$s sera prise en considération.
-RequestEndMessageSingle=le paramètre
-RequestEndMessageMultiple=ces paramètres

--- a/framework/vendor/objects/Request.java
+++ b/framework/vendor/objects/Request.java
@@ -1,6 +1,5 @@
 package vendor.objects;
 
-import vendor.abstracts.Translatable;
 import vendor.interfaces.Utils;
 
 import java.util.ArrayList;
@@ -10,7 +9,7 @@ import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class Request extends Translatable implements Utils {
+public class Request implements Utils {
 	
 	public class Parameter {
 		
@@ -123,12 +122,8 @@ public class Request extends Translatable implements Utils {
 	public final static String DEFAULT_COMMAND_PREFIX = "!";
 	public final static char DEFAULT_PARAMETER_PREFIX = '-';
 	
-	private final static String DEFAULT_LANG_DIRECTORY = "/vendor.lang.strings";
-	
 	private String command;
 	private String content;
-	
-	private String langDirectory;
 	
 	private String commandPrefix;
 	
@@ -136,29 +131,20 @@ public class Request extends Translatable implements Utils {
 	private HashMap<Parameter, ArrayList<String>> parametersLinks;
 	private char parametersPrefix;
 	
-	private String error;
+	private ArrayList<Parameter> duplicateParams;
 	
-	public Request(String receivedMessage, Dictionary dictionary){
-		this(receivedMessage, dictionary, DEFAULT_PARAMETER_PREFIX);
+	public Request(String receivedMessage){
+		this(receivedMessage, DEFAULT_PARAMETER_PREFIX);
 	}
 	
-	public Request(String receivedMessage, Dictionary dictionary,
+	public Request(String receivedMessage,
 			char parametersPrefix){
-		this(receivedMessage, dictionary, DEFAULT_COMMAND_PREFIX,
+		this(receivedMessage, DEFAULT_COMMAND_PREFIX,
 				parametersPrefix);
 	}
 	
-	public Request(String receivedMessage, Dictionary dictionary,
+	public Request(String receivedMessage,
 			String commandPrefix, char parametersPrefix){
-		this(receivedMessage, dictionary, commandPrefix, parametersPrefix,
-				DEFAULT_LANG_DIRECTORY);
-	}
-	
-	public Request(String receivedMessage, Dictionary dictionary,
-			String commandPrefix, char parametersPrefix, String langDirectory){
-		
-		this.setDictionary(dictionary);
-		this.langDirectory = langDirectory;
 		
 		this.commandPrefix = commandPrefix;
 		
@@ -187,7 +173,7 @@ public class Request extends Translatable implements Utils {
 			while(matcher.find()){
 				possibleParams.add(matcher.group());
 			}
-			ArrayList<Parameter> duplicateParams = new ArrayList<>();
+			duplicateParams = new ArrayList<>();
 			
 			boolean canRoll = true;
 			
@@ -331,8 +317,6 @@ public class Request extends Translatable implements Utils {
 			if(getContent() != null)
 				setContent(getContent().trim().replaceAll("\"", ""));
 			
-			handleDuplicateParameter(duplicateParams);
-			
 		}
 		
 	}
@@ -417,14 +401,6 @@ public class Request extends Translatable implements Utils {
 		return Pattern.quote(String.valueOf(getParametersPrefix()));
 	}
 	
-	public String getError(){
-		return this.error;
-	}
-	
-	public boolean hasError(){
-		return this.getError() != null;
-	}
-	
 	// public boolean hasParameter(String parameterName){
 	// 	if(getParameters() == null)
 	// 		return false;
@@ -490,48 +466,52 @@ public class Request extends Translatable implements Utils {
 		
 	}
 	
-	private void handleDuplicateParameter(ArrayList<Parameter> duplicateParams){
+	public ArrayList<Parameter> getDuplicateParamList(){
+		return this.duplicateParams;
+	}
+	
+	public boolean hasError(){
+		return this.getDuplicateParamList() != null;
+	}
+	
+	public String getDefaultErrorMessage(){
 		
-		if(duplicateParams.size() != 0){
+		if(!hasError()){
+			return "This request has no errors!";
+		}
+		else{
 			
 			String pluralTester;
 			
-			if(duplicateParams.size() == 1)
-				pluralTester = langDirect(langDirectory
-						+ ".RequestParamStartSingle");
+			if(this.getDuplicateParamList().size() == 1)
+				pluralTester = "That parameter";
 			else
-				pluralTester = langDirect(langDirectory
-						+ ".RequestParamStartMultiple");
+				pluralTester = "Those parameters";
 			
 			StringBuilder message = new StringBuilder();
 			
 			message.append(pluralTester)
-					.append(" ")
-					.append(langDirect(langDirectory
-							+ ".RequestParamStartFollowing")).append(" ");
+					.append(" has been entered more than once : ");
 			
-			for(int i = 0; i < duplicateParams.size(); i++){
+			for(int i = 0; i < this.getDuplicateParamList().size(); i++){
 				
-				if(duplicateParams.size() != 1)
+				if(this.getDuplicateParamList().size() != 1)
 					message.append("\n").append(i + 1).append(". ");
 				
-				message.append("`").append(duplicateParams.get(i).getName())
-						.append("`");
+				message.append(this.getDuplicateParamList().get(i).getName());
 				
 			}
 			
-			if(duplicateParams.size() == 1)
-				pluralTester = langDirect(langDirectory
-						+ ".RequestEndMessageSingle");
+			if(this.getDuplicateParamList().size() == 1)
+				pluralTester = "the parameter";
 			else
-				pluralTester = langDirect(langDirectory
-						+ ".RequestEndMessageMultiple");
+				pluralTester = "those parameters";
 			
-			message.append("\n*")
-					.append(langDirect(langDirectory + ".RequestEndMessage",
-							pluralTester)).append("*");
+			message.append("\n")
+					.append(format("Only the first instance of {1} will be taken into consideration.",
+							pluralTester));
 			
-			this.error = message.toString();
+			return message.toString();
 			
 		}
 		
@@ -582,6 +562,11 @@ public class Request extends Translatable implements Utils {
 	
 	public void setParamsAsContentLess(
 			ArrayList<String> paramsToTreatAsContentLess){
+		this.setParamsAsContentLess(
+				paramsToTreatAsContentLess.toArray(new String[0]));
+	}
+	
+	public void setParamsAsContentLess(String[] paramsToTreatAsContentLess){
 		
 		for(String paramName : paramsToTreatAsContentLess){
 			try{

--- a/src/app/CommandRouter.java
+++ b/src/app/CommandRouter.java
@@ -30,8 +30,8 @@ public class CommandRouter extends AbstractCommandRouter implements Resources,
 	}
 	
 	@Override
-	protected Request createRequest(String receivedMessage, Dictionary dict){
-		return new Request(receivedMessage, dict, getCommandPrefix(),
+	protected Request createRequest(String receivedMessage){
+		return new Request(receivedMessage, getCommandPrefix(),
 				getCommandParameterPrefix());
 	}
 	
@@ -84,7 +84,7 @@ public class CommandRouter extends AbstractCommandRouter implements Resources,
 					catch(NullPointerException e){}
 					
 					if(request.hasError()){
-						setCommand(new BotError(request.getError(), false));
+						setCommand(new BotError(request.getDefaultErrorMessage(), false));
 						
 						getAbstractBotCommand().action();
 						setCommand(null);

--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -23,11 +23,10 @@ public class Main {
 			
 			String requestableArgs = "RUN_PROGRAM " + convertArgsToString(args);
 			
-			Request programRequest = new Request(requestableArgs,
-					new Dictionary());
+			Request programRequest = new Request(requestableArgs);
 			
 			if(programRequest.hasError()){
-				System.out.println(programRequest.getError());
+				System.out.println(programRequest.getDefaultErrorMessage());
 			}
 			
 			Framework.build(programRequest.hasParameter("d"));


### PR DESCRIPTION
The Request should be as much of an utility as possible, and the links between the bot and it was too strong compared to its utility potential.

I removed the links with `Translatable` and tweaked methods to allow for greater flexibility while allowing for default behavior to still maintain their task (such as the rename of the method `getError()` to `getDefaultErrorMessage()`, which may even allow for other error and not just duplicate params).

This also makes the `Request`'s class file a little more clean to read. I still need to refactor the constructor to modularize it though, as alot (if not all) the logic to create the data from the string is located in the constructor, which is bad practice (and is terrible to look at / debug).