### PR TITLE
Update input after little delay on Terminal log() calls (#5)

### DIFF
--- a/framework/vendor/abstracts/AbstractTerminalConsole.java
+++ b/framework/vendor/abstracts/AbstractTerminalConsole.java
@@ -73,7 +73,7 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 			try{
 				Thread.sleep(250);
 				
-				printGetInputMessage(getLatestInputMessage());
+				printGetInputMessage("\n" + getLatestInputMessage());
 				isWaitingForInput.set(true);
 			}
 			catch(InterruptedException e){}

--- a/framework/vendor/abstracts/AbstractTerminalConsole.java
+++ b/framework/vendor/abstracts/AbstractTerminalConsole.java
@@ -19,6 +19,8 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 	
 	private String inputPrefix;
 	
+	private Thread loggingThread;
+	
 	public AbstractTerminalConsole(){
 		reader = new BufferedReader(new InputStreamReader(System.in));
 		
@@ -42,6 +44,23 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 	@Override
 	public void log(String logText, String logType, boolean hasAppendedDate){
 		System.out.println(logText);
+		
+		if(loggingThread != null){
+			loggingThread.interrupt();
+		}
+			
+		loggingThread = new Thread(() -> {
+			
+			try{
+				Thread.sleep(250);
+				
+				printGetInputMessage();
+			}
+			catch(InterruptedException e){}
+			
+		});
+		
+		loggingThread.start();
 		
 		// logToChannel(logText, logType);
 	}
@@ -99,6 +118,9 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 	public String getInput(String message){
 		
 		printGetInputMessage(message);
+		
+		if(loggingThread != null)
+			loggingThread = null;
 		
 		try{
 			return reader.readLine();

--- a/framework/vendor/abstracts/AbstractTerminalConsole.java
+++ b/framework/vendor/abstracts/AbstractTerminalConsole.java
@@ -23,6 +23,8 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 	private AtomicBoolean isWaitingForInput;
 	private Thread loggingThread;
 	
+	private String latestInputMessage;
+	
 	public AbstractTerminalConsole(){
 		reader = new BufferedReader(new InputStreamReader(System.in));
 		
@@ -30,6 +32,7 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 		
 		this.setInputPrefix(">");
 		this.isWaitingForInput.set(false);
+		this.latestInputMessage = "";
 	}
 	
 	public CommandsRepository getCommandsRepo(){
@@ -46,6 +49,10 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 	
 	public boolean isWaitingForInput(){
 		return this.isWaitingForInput.get();
+	}
+	
+	protected String getLatestInputMessage() {
+		return this.latestInputMessage;
 	}
 	
 	@Override
@@ -66,7 +73,7 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 			try{
 				Thread.sleep(250);
 				
-				printGetInputMessage();
+				printGetInputMessage(getLatestInputMessage());
 				isWaitingForInput.set(true);
 			}
 			catch(InterruptedException e){}
@@ -131,6 +138,7 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 	public String getInput(String message){
 		
 		printGetInputMessage(message);
+		this.latestInputMessage = message;
 		
 		if(loggingThread != null)
 			loggingThread = null;

--- a/framework/vendor/abstracts/AbstractTerminalConsole.java
+++ b/framework/vendor/abstracts/AbstractTerminalConsole.java
@@ -57,17 +57,17 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 		return this.isLogging.get();
 	}
 	
-	protected String getLatestInputMessage() {
+	protected String getLatestInputMessage(){
 		return this.latestInputMessage;
 	}
 	
 	@Override
 	public void log(String logText, String logType, boolean hasAppendedDate){
 		
-		this.isLogging.set(true);
-		
-		if(this.isWaitingForInput())
+		if(this.isWaitingForInput() && !this.isLogging())
 			System.out.println("---\n");
+		
+		this.isLogging.set(true);
 		
 		System.out.println(logText);
 		
@@ -75,7 +75,7 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 			this.isLogging.set(false);
 		}
 		else{
-		
+			
 			if(loggingThread != null)
 				loggingThread.interrupt();
 			
@@ -85,10 +85,10 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 					Thread.sleep(250);
 					
 					printGetInputMessage(getLatestInputMessage());
+					
+					isLogging.set(false);
 				}
 				catch(InterruptedException e){}
-				
-				isLogging.set(false);
 				
 			});
 			
@@ -191,7 +191,7 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 			};
 			break;
 		}
-
+		
 		String choiceSeparator = " / ";
 		
 		StringBuilder choiceBuilder = new StringBuilder();
@@ -202,8 +202,8 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 			choiceBuilder.append(possibility).append(choiceSeparator);
 		}
 		
-		choiceBuilder
-				.delete(choiceBuilder.length() - choiceSeparator.length(), choiceBuilder.length());
+		choiceBuilder.delete(choiceBuilder.length() - choiceSeparator.length(),
+				choiceBuilder.length());
 		
 		choiceBuilder.append(")");
 		

--- a/framework/vendor/abstracts/AbstractTerminalConsole.java
+++ b/framework/vendor/abstracts/AbstractTerminalConsole.java
@@ -65,11 +65,11 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 	public void log(String logText, String logType, boolean hasAppendedDate){
 		
 		if(this.isWaitingForInput() && !this.isLogging())
-			System.out.println("---\n");
+			this.sendLog("---\n");
 		
 		this.isLogging.set(true);
 		
-		System.out.println(logText);
+		this.sendLog(logText);
 		
 		if(!this.isWaitingForInput()){
 			this.isLogging.set(false);
@@ -97,6 +97,17 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 		}
 		
 		// logToChannel(logText, logType);
+	}
+	
+	protected void sendLog(String log){
+		this.sendLog(log, true);
+	}
+	
+	protected void sendLog(String log, boolean appendNewLine){
+		if(appendNewLine)
+			System.out.println(log);
+		else
+			System.out.print(log);
 	}
 	
 	/**
@@ -143,7 +154,7 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 	}
 	
 	private void printGetInputMessage(String message){
-		System.out.print("\n" + message + " ");
+		sendLog("\n" + message + " ", false);
 	}
 	
 	public String getInput(){


### PR DESCRIPTION
I used a stored Thread to update the input stream after a `log()` has been sent.

Basically, if no `log()` is sent after 250 milliseconds after the first `log()`, it will print the input's ~default command waiting~ latest sent message. Otherwise, reset the timer and wait again.

This delay is there to allow successive logs to be entered but not interfere _too much_ with the user's input : otherwise, it may print the log - input message - log - input message - log - input message. Yes, this would be terrible to look at, especially if new lines are used to separate logs from user interactions (which is what is happening) :)

TODO :
- [x] use latest message instead of default input char
    - this would be required because we don't know what input is required at said moment : it might be a confirmation or simply waiting for a command to be entered.

Note :
This PR does not suspend the BufferedReader that tries to take the user's input, which means that during the log's delay, a user might potentially start writing a command and get confused as to why only a subpart of his input is shown next to the input message. This will be put into a new issue if the problem is as I imagine : I'll see after testing this PR.

Closes #5