### PR TITLE
Fix any System.out calls to trigger the input update when using AbstractTerminalConsole

### DIFF
--- a/framework/vendor/abstracts/AbstractTerminalConsole.java
+++ b/framework/vendor/abstracts/AbstractTerminalConsole.java
@@ -32,7 +32,7 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 		this.outputStream = new UpdatableOutputStream(System.out, UpdatableOutputStream.Type.OUT){
 			@Override
 			public void onSetupInputAgain(String latestMessage) {
-				AbstractTerminalConsole.this.printGetInputMessage(getLatestInputMessage());
+				AbstractTerminalConsole.this.printGetInputMessage(latestMessage);
 			}
 		
 			@Override

--- a/framework/vendor/abstracts/AbstractTerminalConsole.java
+++ b/framework/vendor/abstracts/AbstractTerminalConsole.java
@@ -31,8 +31,8 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 		
 		this.outputStream = new UpdatableOutputStream(System.out, UpdatableOutputStream.Type.OUT){
 			@Override
-			public void onSetupInputAgain(String latestMessage) {
-				AbstractTerminalConsole.this.printGetInputMessage(latestMessage);
+			public String formatLatestInputMessage(String latestMessage) {
+				return AbstractTerminalConsole.this.formatInputMessage(latestMessage);
 			}
 		
 			@Override
@@ -55,7 +55,7 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 	}
 	
 	protected void setIsWaitingForInput(boolean isWaitingForInput){
-		this.outputStream.setIsWaitingForInput(isWaitingForInput);;
+		this.outputStream.setIsWaitingForInput(isWaitingForInput);
 	}
 	
 	public boolean isWaitingForInput(){
@@ -132,7 +132,11 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 	}
 	
 	protected void printGetInputMessage(String message){
-		sendLog("\n" + message + " ", false);
+		sendLog(formatInputMessage(message), false);
+	}
+	
+	protected String formatInputMessage(String message){
+		return "\n" + message + " ";
 	}
 	
 	public String getInput(){
@@ -143,7 +147,7 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 	public String getInput(String message){
 		
 		printGetInputMessage(message);
-		this.outputStream.setLatestInputMessage(message);;
+		this.outputStream.setLatestInputMessage(message);
 		
 		this.setIsWaitingForInput(true);
 		

--- a/framework/vendor/abstracts/AbstractTerminalConsole.java
+++ b/framework/vendor/abstracts/AbstractTerminalConsole.java
@@ -29,14 +29,16 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 		
 		this.setInputPrefix(">");
 		
-		this.outputStream = new UpdatableOutputStream(System.out, UpdatableOutputStream.Type.OUT){
+		this.outputStream = new UpdatableOutputStream(System.out,
+				UpdatableOutputStream.Type.OUT){
 			@Override
-			public String formatLatestInputMessage(String latestMessage) {
-				return AbstractTerminalConsole.this.formatInputMessage(latestMessage);
+			public String formatLatestInputMessage(String latestMessage){
+				return AbstractTerminalConsole.this
+						.formatInputMessage(latestMessage);
 			}
-		
+			
 			@Override
-			public String getUpdatingString() {
+			public String getUpdatingString(){
 				return "---";
 			}
 		};
@@ -209,7 +211,8 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 		
 		do{
 			
-			String input = getInput(question + " " + choiceBuilder.toString()).trim();
+			String input = getInput(question + " " + choiceBuilder.toString())
+					.trim();
 			
 			System.out.println();
 			

--- a/framework/vendor/abstracts/AbstractTerminalConsole.java
+++ b/framework/vendor/abstracts/AbstractTerminalConsole.java
@@ -255,6 +255,8 @@ public abstract class AbstractTerminalConsole implements Console, Loggable {
 	public void onInitialized(){}
 	
 	@Override
-	public void onExit() throws Exception{}
+	public void onExit() throws Exception{
+		this.outputStream.resetStream();
+	}
 	
 }

--- a/framework/vendor/consoles/utils/UpdatableOutputStream.java
+++ b/framework/vendor/consoles/utils/UpdatableOutputStream.java
@@ -34,16 +34,17 @@ public abstract class UpdatableOutputStream extends PrintStream {
 		this.updateSystemOutput(this);
 	}
 	
-	
 	public void setIsWaitingForInput(boolean isWaitingForInput){
 		this.isWaitingForInput = isWaitingForInput;
 	}
+	
 	public void setIsPrinting(boolean isPrinting){
 		this.isPrinting = isPrinting;
 		
 		if(isPrinting == false && this.loggingThread != null)
 			this.loggingThread = null;
 	}
+	
 	public void setDelayedUpdate(int delayedUpdate){
 		this.delayedUpdate = delayedUpdate;
 	}
@@ -51,9 +52,11 @@ public abstract class UpdatableOutputStream extends PrintStream {
 	public boolean isWaitingForInput(){
 		return this.isWaitingForInput;
 	}
+	
 	public boolean isPrinting(){
 		return this.isPrinting;
 	}
+	
 	public int getDelayedUpdate(){
 		return this.delayedUpdate;
 	}
@@ -61,6 +64,7 @@ public abstract class UpdatableOutputStream extends PrintStream {
 	public String getLatestInputMessage(){
 		return this.latestInputMessage;
 	}
+	
 	public void setLatestInputMessage(String message){
 		this.latestInputMessage = message;
 	}
@@ -71,13 +75,13 @@ public abstract class UpdatableOutputStream extends PrintStream {
 	
 	protected void updateSystemOutput(PrintStream printStream){
 		switch(this.outputType){
-			default:
-			case OUT:
-				System.setOut(printStream);
-				break;
-			case ERR:
-				System.setErr(printStream);
-				break;
+		default:
+		case OUT:
+			System.setOut(printStream);
+			break;
+		case ERR:
+			System.setErr(printStream);
+			break;
 		}
 	}
 	
@@ -102,22 +106,23 @@ public abstract class UpdatableOutputStream extends PrintStream {
 			if(loggingThread != null)
 				loggingThread.interrupt();
 			
-			loggingThread = new Thread(() -> {
-				
-				try{
-					Thread.sleep(getDelayedUpdate());
-					
-					if(isWaitingForInput()){
+			loggingThread = new Thread(
+					() -> {
 						
-						super.print(formatLatestInputMessage(getLatestInputMessage()));
+						try{
+							Thread.sleep(getDelayedUpdate());
+							
+							if(isWaitingForInput()){
+								
+								super.print(formatLatestInputMessage(getLatestInputMessage()));
+								
+								setIsPrinting(false);
+								
+							}
+						}
+						catch(InterruptedException e){}
 						
-						setIsPrinting(false);
-						
-					}
-				}
-				catch(InterruptedException e){}
-				
-			});
+					});
 			
 			loggingThread.start();
 			
@@ -173,7 +178,8 @@ public abstract class UpdatableOutputStream extends PrintStream {
 	}
 	
 	@Override
-	public PrintStream format(final Locale l, final String format, final Object... args){
+	public PrintStream format(final Locale l, final String format,
+			final Object... args){
 		AtomicReference<PrintStream> returnVal = new AtomicReference<>();
 		
 		handlePrint(() -> returnVal.set(super.format(l, format, args)));

--- a/framework/vendor/consoles/utils/UpdatableOutputStream.java
+++ b/framework/vendor/consoles/utils/UpdatableOutputStream.java
@@ -41,7 +41,7 @@ public abstract class UpdatableOutputStream extends PrintStream {
 	public void setIsPrinting(boolean isPrinting){
 		this.isPrinting = isPrinting;
 		
-		if(this.loggingThread != null)
+		if(isPrinting == false && this.loggingThread != null)
 			this.loggingThread = null;
 	}
 	public void setDelayedUpdate(int delayedUpdate){
@@ -83,7 +83,7 @@ public abstract class UpdatableOutputStream extends PrintStream {
 	
 	public abstract String getUpdatingString();
 	
-	public abstract void onSetupInputAgain(String latestMessage);
+	public abstract String formatLatestInputMessage(String latestMessage);
 	
 	private void handlePrint(Runnable action){
 		
@@ -109,7 +109,7 @@ public abstract class UpdatableOutputStream extends PrintStream {
 					
 					if(isWaitingForInput()){
 						
-						onSetupInputAgain(getLatestInputMessage());
+						super.print(formatLatestInputMessage(getLatestInputMessage()));
 						
 						setIsPrinting(false);
 						


### PR DESCRIPTION
~This has not been tested at all yet~, but the logic seems to be good enough.

~There is currently no call to return the original PrintStream object back to the System.~

Closes #130