### PR TITLE
Fix spam doing nothing when invalid user #142

### DIFF
--- a/src/commands/CommandSpam.java
+++ b/src/commands/CommandSpam.java
@@ -48,6 +48,9 @@ public class CommandSpam extends BotCommand {
 											.getRoleById(
 													getIdFromStringMentionRole(possibleMention)));
 				}
+				else{
+					throw new BadContentException();
+				}
 				
 			}
 			catch(BadContentException e){


### PR DESCRIPTION
This PR should fix the problem where entering anything that is not a user or a role with the `-u` parameter for the spam command would not do anything (not even show an error / usage message.

Closes #142