### PR TITLE
Change exception handling of sanitizers to BadFormatException for clarity

### DIFF
--- a/framework/vendor/exceptions/BadFormatException.java
+++ b/framework/vendor/exceptions/BadFormatException.java
@@ -1,6 +1,6 @@
 package vendor.exceptions;
 
-public class BadFormatException extends RuntimeException {
+public class BadFormatException extends IllegalArgumentException {
 	
 	private int code;
 	

--- a/framework/vendor/exceptions/BadFormatException.java
+++ b/framework/vendor/exceptions/BadFormatException.java
@@ -1,13 +1,33 @@
 package vendor.exceptions;
 
-public class BadFormatException extends Exception {
+public class BadFormatException extends RuntimeException {
+	
+	private int code;
+	
+	public static final int DEFAULT_ERROR_CODE = -1;
 	
 	public BadFormatException(){
+		this(DEFAULT_ERROR_CODE);
+	}
+	
+	public BadFormatException(int errorCode){
 		super();
+		
+		this.code = errorCode;
 	}
 	
 	public BadFormatException(String message){
+		this(message, DEFAULT_ERROR_CODE);
+	}
+	
+	public BadFormatException(String message, int errorCode){
 		super(message);
+		
+		this.code = errorCode;
+	}
+	
+	public int getErrorCode(){
+		return this.code;
 	}
 	
 }

--- a/framework/vendor/utilities/sanitizers/BooleanSanitizer.java
+++ b/framework/vendor/utilities/sanitizers/BooleanSanitizer.java
@@ -1,8 +1,10 @@
 package vendor.utilities.sanitizers;
 
+import vendor.exceptions.BadFormatException;
+
 public interface BooleanSanitizer {
 	
-	static boolean sanitizeValue(Object value) throws IllegalArgumentException{
+	static boolean sanitizeValue(Object value) throws BadFormatException{
 		
 		boolean castedValue;
 		
@@ -27,8 +29,8 @@ public interface BooleanSanitizer {
 			
 		}
 		catch(Exception e){
-			throw new IllegalArgumentException(
-					"Value cannot be something else than \"true\" or \"false\"!");
+			throw new BadFormatException(
+					"Value cannot be something else than \"true\" or \"false\"!", 1);
 		}
 		
 		return castedValue;

--- a/framework/vendor/utilities/sanitizers/CharSanitizer.java
+++ b/framework/vendor/utilities/sanitizers/CharSanitizer.java
@@ -1,14 +1,16 @@
 package vendor.utilities.sanitizers;
 
+import vendor.exceptions.BadFormatException;
+
 public interface CharSanitizer {
 	
-	static char sanitizeValue(Object value) throws IllegalArgumentException{
+	static char sanitizeValue(Object value) throws BadFormatException{
 		
 		String stringValue = TextSanitizer.sanitizeValue(value);
 		
 		if(stringValue.length() != 1){
-			throw new IllegalArgumentException(
-					"Only one character is expected!");
+			throw new BadFormatException(
+					"Only one character is expected!", 1);
 		}
 		
 		return stringValue.charAt(0);

--- a/framework/vendor/utilities/sanitizers/EnumSanitizer.java
+++ b/framework/vendor/utilities/sanitizers/EnumSanitizer.java
@@ -2,16 +2,18 @@ package vendor.utilities.sanitizers;
 
 import java.util.ArrayList;
 
+import vendor.exceptions.BadFormatException;
+
 public interface EnumSanitizer {
 	
 	static String sanitizeValue(Object value, ArrayList<String> values)
-			throws IllegalArgumentException{
+			throws BadFormatException{
 		
 		String stringValue = TextSanitizer.sanitizeValue(value);
 		
 		if(!values.contains(stringValue)){
-			throw new IllegalArgumentException("The value " + stringValue
-					+ " is not a choice for this setting!");
+			throw new BadFormatException("The value " + stringValue
+					+ " is not a choice for this setting!", 1);
 		}
 		
 		return stringValue;

--- a/framework/vendor/utilities/sanitizers/TextLengthSanitizer.java
+++ b/framework/vendor/utilities/sanitizers/TextLengthSanitizer.java
@@ -1,33 +1,37 @@
 package vendor.utilities.sanitizers;
 
+import vendor.exceptions.BadFormatException;
+
 public interface TextLengthSanitizer {
 	
-	static String sanitizeValueMin(Object value, int minLength){
+	static String sanitizeValueMin(Object value, int minLength)
+			throws BadFormatException{
 		return TextLengthSanitizer.sanitizeValue(value, minLength,
 				Integer.MAX_VALUE);
 	}
 	
-	static String sanitizeValueMax(Object value, int maxLength){
+	static String sanitizeValueMax(Object value, int maxLength)
+			throws BadFormatException{
 		return TextLengthSanitizer.sanitizeValue(value, Integer.MIN_VALUE,
 				maxLength);
 	}
 	
 	static String sanitizeValue(Object value, int minLength, int maxLength)
-			throws IllegalArgumentException{
+			throws BadFormatException{
 		
 		String stringValue = TextSanitizer.sanitizeValue(value);
 		
 		int stringLength = stringValue.length();
 		
 		if(minLength != Integer.MIN_VALUE && stringLength < minLength){
-			throw new IllegalArgumentException(
+			throw new BadFormatException(
 					"This setting's value needs to have at least " + minLength
-							+ " characters!");
+							+ " characters!", 1);
 		}
 		else if(maxLength != Integer.MAX_VALUE && stringLength > maxLength){
-			throw new IllegalArgumentException(
+			throw new BadFormatException(
 					"This setting's value cannot have more than " + maxLength
-							+ " characters!");
+							+ " characters!", 2);
 		}
 		
 		return stringValue;

--- a/framework/vendor/utilities/sanitizers/TextNotEmptySanitizer.java
+++ b/framework/vendor/utilities/sanitizers/TextNotEmptySanitizer.java
@@ -1,13 +1,15 @@
 package vendor.utilities.sanitizers;
 
+import vendor.exceptions.BadFormatException;
+
 public interface TextNotEmptySanitizer {
 	
-	static String sanitizeValue(Object value) throws IllegalArgumentException{
+	static String sanitizeValue(Object value) throws BadFormatException{
 		
 		String stringValue = TextSanitizer.sanitizeValue(value);
 		
 		if(stringValue.length() == 0){
-			throw new IllegalArgumentException("Value cannot be empty!");
+			throw new BadFormatException("Value cannot be empty!", 1);
 		}
 		
 		return stringValue;

--- a/framework/vendor/utilities/sanitizers/TextRegexSanitizer.java
+++ b/framework/vendor/utilities/sanitizers/TextRegexSanitizer.java
@@ -3,15 +3,17 @@ package vendor.utilities.sanitizers;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import vendor.exceptions.BadFormatException;
+
 public interface TextRegexSanitizer {
 	
 	static String sanitizeValue(Object value, String regexToMatch)
-			throws IllegalArgumentException, PatternSyntaxException{
+			throws BadFormatException, PatternSyntaxException{
 		return TextRegexSanitizer.sanitizeValue(value, regexToMatch, false);
 	}
 	
 	static String sanitizeValue(Object value, String regexToMatch,
-			boolean isInverted) throws IllegalArgumentException,
+			boolean isInverted) throws BadFormatException,
 			PatternSyntaxException{
 		return TextRegexSanitizer.sanitizeValue(value, regexToMatch,
 				isInverted, true);
@@ -19,14 +21,14 @@ public interface TextRegexSanitizer {
 	
 	static String sanitizeValue(Object value, String regexToMatch,
 			boolean isInverted, boolean shouldBox)
-			throws IllegalArgumentException, PatternSyntaxException{
+			throws BadFormatException, PatternSyntaxException{
 		return TextRegexSanitizer.sanitizeValue(value, regexToMatch,
 				isInverted, shouldBox, true);
 	}
 	
 	static String sanitizeValue(Object value, String regexToMatch,
 			boolean isInverted, boolean shouldBox, boolean shouldCheckPattern)
-			throws IllegalArgumentException, PatternSyntaxException{
+			throws BadFormatException, PatternSyntaxException{
 		
 		String stringValue = TextSanitizer.sanitizeValue(value);
 		
@@ -43,8 +45,8 @@ public interface TextRegexSanitizer {
 			
 			// Test regex and invert if we need to
 			if(stringValue.matches(regexToMatch) == isInverted){
-				throw new IllegalArgumentException(
-						"Value does not match the required pattern!");
+				throw new BadFormatException(
+						"Value does not match the required pattern!", 1);
 			}
 			
 		}

--- a/framework/vendor/utilities/sanitizers/TextSanitizer.java
+++ b/framework/vendor/utilities/sanitizers/TextSanitizer.java
@@ -2,7 +2,7 @@ package vendor.utilities.sanitizers;
 
 public interface TextSanitizer {
 	
-	static String sanitizeValue(Object value) throws IllegalArgumentException{
+	static String sanitizeValue(Object value){
 		
 		if(value == null)
 			return "";

--- a/framework/vendor/utilities/settings/Setting.java
+++ b/framework/vendor/utilities/settings/Setting.java
@@ -1,5 +1,6 @@
 package vendor.utilities.settings;
 
+import vendor.exceptions.BadFormatException;
 import vendor.objects.Dictionary;
 
 import java.util.HashMap;
@@ -26,7 +27,7 @@ public class Setting {
 	}
 	
 	public boolean save(String settingName, Object value,
-			Consumer<Object> onChange) throws IllegalArgumentException{
+			Consumer<Object> onChange) throws BadFormatException{
 		
 		if(!hasField(settingName)){
 			return false;

--- a/framework/vendor/utilities/settings/SettingField.java
+++ b/framework/vendor/utilities/settings/SettingField.java
@@ -1,6 +1,7 @@
 package vendor.utilities.settings;
 
 import vendor.abstracts.Translatable;
+import vendor.exceptions.BadFormatException;
 import vendor.modules.Environment;
 import vendor.modules.Logger;
 import vendor.modules.Logger.LogType;
@@ -61,7 +62,7 @@ public abstract class SettingField<E> extends Translatable {
 		return this.defaultValue;
 	}
 	
-	public final void setValue(E value) throws IllegalArgumentException{
+	public final void setValue(E value) throws BadFormatException{
 		this.setValue(value, null);
 	}
 	
@@ -74,10 +75,10 @@ public abstract class SettingField<E> extends Translatable {
 	}
 	
 	public final void setValue(E value, Consumer<E> onChange)
-			throws IllegalArgumentException{
+			throws BadFormatException{
 		
 		if(value == null){
-			throw new IllegalArgumentException("Value cannot be null!");
+			throw new BadFormatException("Value cannot be null!", 0);
 		}
 		
 		this.value = this.sanitizeValue(value);

--- a/src/commands/CommandSetting.java
+++ b/src/commands/CommandSetting.java
@@ -3,6 +3,7 @@ package commands;
 import errorHandling.BotError;
 import utilities.BotCommand;
 import utilities.music.MusicManager;
+import vendor.exceptions.BadFormatException;
 import vendor.objects.ParametersHelp;
 import vendor.utilities.settings.SettingField;
 
@@ -112,7 +113,7 @@ public class CommandSetting extends BotCommand {
 						try{
 							setSetting(settingName, parameterContent, onSuccess);
 						}
-						catch(IllegalArgumentException e){
+						catch(BadFormatException e){
 							new BotError(this, e.getMessage());
 						}
 						

--- a/src/utilities/BotCommand.java
+++ b/src/utilities/BotCommand.java
@@ -3,6 +3,7 @@ package utilities;
 import app.CommandRouter;
 import utilities.interfaces.*;
 import vendor.abstracts.AbstractBotCommand;
+import vendor.exceptions.BadFormatException;
 import vendor.utilities.settings.Setting;
 
 import java.util.function.Consumer;
@@ -46,12 +47,13 @@ public abstract class BotCommand extends AbstractBotCommand implements
 		
 	}
 	
-	public void setSetting(String settingName, Object value){
+	public void setSetting(String settingName, Object value)
+			throws BadFormatException{
 		this.setSetting(settingName, value, null);
 	}
 	
 	public void setSetting(String settingName, Object value,
-			Consumer<Object> onChange){
+			Consumer<Object> onChange) throws BadFormatException{
 		
 		Setting settings = this.getSettings();
 		


### PR DESCRIPTION
This will especially be useful for the future where we'll want to localize error codes (currently, we are using the Sanitizer's default message for bad sanitizations, and while it works, it can't change the language using the `\lang` command).

Also, it just makes much more sense to use BadFormatException (*which is an IllegalArgumentException now anyway*).