### PR TITLE
Refactor CommandSetting, allowing more flexibility in param actions

### DIFF
--- a/src/commands/CommandSetting.java
+++ b/src/commands/CommandSetting.java
@@ -4,122 +4,216 @@ import errorHandling.BotError;
 import utilities.BotCommand;
 import utilities.music.MusicManager;
 import vendor.exceptions.BadFormatException;
+import vendor.modules.Logger;
 import vendor.objects.ParametersHelp;
+import vendor.objects.Request.Parameter;
 import vendor.utilities.settings.SettingField;
 
+import java.util.ArrayList;
 import java.util.function.Consumer;
 
 public class CommandSetting extends BotCommand {
 	
+	protected abstract class SettingChanger<T> extends BotCommand {
+		
+		public boolean shouldSendMessages;
+		
+		private String settingName;
+		private String parameterName;
+		private boolean isPresent;
+		
+		public SettingChanger(String settingName, String parameterName){
+			super(CommandSetting.this);
+			
+			this.shouldSendMessages = true;
+			this.settingName = settingName;
+			this.parameterName = parameterName;
+			this.isPresent = this.hasParameter(this.parameterName);
+			
+			CommandSetting.this.settings.add(this);
+		}
+		
+		@Override
+		public void action() {
+			
+			@SuppressWarnings("unchecked")
+			Consumer<Object> onSuccess = (value) -> {
+				try{
+					onSuccess((T)value);
+				}
+				catch(ClassCastException e){
+					Logger.log("One of your SettingChanger is not well typed : make sure that your settings configuration and your SettingChanger in CommandSetting are synchronized correctly!", Logger.LogType.ERROR);
+				}
+			};
+			
+			Parameter param = getParameter(this.parameterName);
+			
+			String parameterContent = param.getContent();
+				
+			if(parameterContent == null){
+				
+				SettingField<Object> settingField = getSettings()
+						.getField(this.settingName);
+				
+				if(CommandSetting.this.shouldSwitchToDefault){
+					
+					this.setSendable(false);
+					
+					settingField.setToDefaultValue(onSuccess);
+					
+					sendMessage("The setting "
+							+ code(settingName)
+							+ " has been set back to its default ("
+							+ ital(code(settingField.getDefaultValue()))
+							+ ")!");
+					
+				}
+				else{
+					
+					this.setSendable(false);
+					
+					Object defaultSettingValue = settingField
+							.getDefaultValue();
+					Object currentSettingValue = settingField
+							.getValue();
+					
+					sendMessage("The default value for the setting "
+							+ code(settingName) + " is : "
+							+ ital(code(defaultSettingValue))
+							+ ". Current value : "
+							+ code(currentSettingValue) + ".");
+					
+				}
+				
+			}
+			else{
+				
+				try{
+					setSetting(settingName, parameterContent, onSuccess);
+				}
+				catch(BadFormatException e){
+					new BotError(this, e.getMessage());
+				}
+				
+			}
+			
+		}
+		
+		public abstract void onSuccess(T value);
+		
+		public boolean isPresent(){
+			return this.isPresent;
+		}
+		
+		public void setSendable(boolean shouldSendMessages){
+			this.shouldSendMessages = shouldSendMessages;
+		}
+		
+		@Override
+		public Object getCalls() {
+			return null;
+		}
+		
+		@Override
+		public String sendMessage(String messageToSend) {
+			return this.shouldSendMessages ? super.sendMessage(messageToSend) : null;
+		}
+		
+		@Override
+		public String lang(String key) {
+			return this.shouldSendMessages ? super.lang(key) : null;
+		}
+		
+		@Override
+		public String lang(String key, Object... replacements) {
+			return this.shouldSendMessages ? super.lang(key, replacements) : null;
+		}
+		
+	}
+	
 	private boolean shouldSwitchToDefault;
+	private ArrayList<SettingChanger<?>> settings = new ArrayList<>();
 	
 	@Override
 	public void action(){
 		
 		this.shouldSwitchToDefault = hasParameter("d");
 		
-		tryAndChangeSetting("prefix", "prefix", (value) -> {
-			sendMessage("You switched the prefix to " + code(value) + "!");
-		});
+		this.setupSettings();
 		
-		tryAndChangeSetting(
-				"param_prefix",
-				"param_prefix",
-				(value) -> {
-					sendMessage("You switched the parameters prefix to "
-							+ code(value)
-							+ " ("
-							+ ital("and of course "
-									+ code(value.toString() + value.toString()))
-							+ ")!");
-				});
+		boolean hasAtLeastOneSetting = false;
 		
-		tryAndChangeSetting("nickname", "nickname", (value) -> {
-			setSelfNickname(value.toString());
+		for(SettingChanger<?> setting : settings){
 			
-			sendMessage("The nickname of the bot is now set to " + code(value)
-					+ "!");
-		});
-		
-		tryAndChangeSetting(
-				"confirm_stop",
-				"confirm_stop",
-				(value) -> {
-					boolean isConfirming = (boolean)value;
-					
-					if(isConfirming){
-						sendMessage("Stopping the most recent running command will now ask for a confirmation.");
-					}
-					else{
-						sendMessage("Stopping the most recent running command will not ask for a confirmation anymore.");
-					}
-				});
-		
-		tryAndChangeSetting("volume", "volume", (value) -> {
-			
-			if(MusicManager.get().hasPlayer(this.getGuild())){
-				MusicManager.get().getPlayer(this).setVolume((int)value);
+			if(setting.isPresent()){
+				
+				setting.action();
+				
+				if(!hasAtLeastOneSetting)
+					hasAtLeastOneSetting = true;
+				
 			}
 			
-			sendMessage("The default volume will now be " + code(value) + "!");
-			
-		});
+		}
+		
+		if(!hasAtLeastOneSetting){
+			new BotError(this, "You haven't entered a single setting parameter to change - get to know which ones are available using " + buildVCommand(HELP + " " + "setting") + "!");
+		}
 		
 	}
 	
-	public void tryAndChangeSetting(String settingName, String parameterName,
-			Consumer<Object> onSuccess){
+	protected void setupSettings(){
 		
-		onParameterPresent(
-				parameterName,
-				param -> {
-					
-					String parameterContent = param.getContent();
-					
-					if(parameterContent == null){
-						
-						SettingField<Object> settingField = getSettings()
-								.getField(settingName);
-						
-						if(this.shouldSwitchToDefault){
-							
-							settingField.setToDefaultValue(onSuccess);
-							
-							sendMessage("The setting "
-									+ code(settingName)
-									+ " has been set back to its default ("
-									+ ital(code(settingField.getDefaultValue()))
-									+ ")!");
-							
-						}
-						else{
-							
-							Object defaultSettingValue = settingField
-									.getDefaultValue();
-							Object currentSettingValue = settingField
-									.getValue();
-							
-							sendMessage("The default value for the setting "
-									+ code(settingName) + " is : "
-									+ ital(code(defaultSettingValue))
-									+ ". Current value : "
-									+ code(currentSettingValue) + ".");
-							
-						}
-						
-					}
-					else{
-						
-						try{
-							setSetting(settingName, parameterContent, onSuccess);
-						}
-						catch(BadFormatException e){
-							new BotError(this, e.getMessage());
-						}
-						
-					}
-					
-				});
+		new SettingChanger<String>("prefix", "prefix"){
+			@Override
+			public void onSuccess(String newPrefix){
+				sendMessage("You switched the prefix to " + code(newPrefix) + "!");
+			}
+		};
+		
+		new SettingChanger<Character>("param_prefix", "param_prefix"){
+			@Override
+			public void onSuccess(Character newParamPrefix){
+				sendMessage("You switched the parameters prefix to "
+						+ code(newParamPrefix) + " ("
+						+ ital("and of course "
+								+ code(newParamPrefix + "" + newParamPrefix))
+						+ ")!");
+			}
+		};
+		
+		new SettingChanger<String>("nickname", "nickname"){
+			@Override
+			public void onSuccess(String newNickname){
+				setSelfNickname(newNickname);
+				
+				sendMessage("The nickname of the bot is now set to "
+						+ code(newNickname) + "!");
+			}
+		};
+		
+		new SettingChanger<Boolean>("confirm_stop", "confirm_stop"){
+			@Override
+			public void onSuccess(Boolean isConfirming){
+				if(isConfirming){
+					sendMessage("Stopping the most recent running command will now ask for a confirmation.");
+				}
+				else{
+					sendMessage("Stopping the most recent running command will not ask for a confirmation anymore.");
+				}
+			}
+		};
+		
+		new SettingChanger<Integer>("volume", "volume"){
+			@Override
+			public void onSuccess(Integer volume){
+				if(MusicManager.get().hasPlayer(this.getGuild())){
+					MusicManager.get().getPlayer(this).setVolume(volume);
+				}
+				
+				sendMessage("The default volume will now be " + code(volume) + "!");
+			}
+		};
 		
 	}
 	

--- a/src/commands/CommandSetting.java
+++ b/src/commands/CommandSetting.java
@@ -22,6 +22,10 @@ public class CommandSetting extends BotCommand {
 		private String parameterName;
 		private boolean isPresent;
 		
+		public SettingChanger(String settingAndParamName){
+			this(settingAndParamName, settingAndParamName);
+		}
+		
 		public SettingChanger(String settingName, String parameterName){
 			super(CommandSetting.this);
 			
@@ -164,14 +168,14 @@ public class CommandSetting extends BotCommand {
 	
 	protected void setupSettings(){
 		
-		new SettingChanger<String>("prefix", "prefix"){
+		new SettingChanger<String>("prefix"){
 			@Override
 			public void onSuccess(String newPrefix){
 				sendMessage("You switched the prefix to " + code(newPrefix) + "!");
 			}
 		};
 		
-		new SettingChanger<Character>("param_prefix", "param_prefix"){
+		new SettingChanger<Character>("param_prefix"){
 			@Override
 			public void onSuccess(Character newParamPrefix){
 				sendMessage("You switched the parameters prefix to "
@@ -182,7 +186,7 @@ public class CommandSetting extends BotCommand {
 			}
 		};
 		
-		new SettingChanger<String>("nickname", "nickname"){
+		new SettingChanger<String>("nickname"){
 			@Override
 			public void onSuccess(String newNickname){
 				setSelfNickname(newNickname);
@@ -192,7 +196,7 @@ public class CommandSetting extends BotCommand {
 			}
 		};
 		
-		new SettingChanger<Boolean>("confirm_stop", "confirm_stop"){
+		new SettingChanger<Boolean>("confirm_stop"){
 			@Override
 			public void onSuccess(Boolean isConfirming){
 				if(isConfirming){
@@ -204,7 +208,7 @@ public class CommandSetting extends BotCommand {
 			}
 		};
 		
-		new SettingChanger<Integer>("volume", "volume"){
+		new SettingChanger<Integer>("volume"){
 			@Override
 			public void onSuccess(Integer volume){
 				if(MusicManager.get().hasPlayer(this.getGuild())){

--- a/src/commands/CommandSetting.java
+++ b/src/commands/CommandSetting.java
@@ -65,6 +65,8 @@ public class CommandSetting extends BotCommand {
 					
 					settingField.setToDefaultValue(onSuccess);
 					
+					this.setSendable(true);
+					
 					sendMessage("The setting "
 							+ code(settingName)
 							+ " has been set back to its default ("
@@ -73,8 +75,6 @@ public class CommandSetting extends BotCommand {
 					
 				}
 				else{
-					
-					this.setSendable(false);
 					
 					Object defaultSettingValue = settingField
 							.getDefaultValue();

--- a/src/commands/CommandSetting.java
+++ b/src/commands/CommandSetting.java
@@ -260,7 +260,7 @@ public class CommandSetting extends BotCommand {
 									.getDefaultValue()) + ".", "volume"),
 			new ParametersHelp(
 					"Switch to allow for putting back the default value for each settings as parameters quickly.",
-					false, "d")
+					false, "d", "default")
 		};
 	}
 	


### PR DESCRIPTION
- Sending messages onSuccess of changing a setting can now be turned off, useful for switching back to default
- Easier handling of known to-change parameters
- Add error message when no parameters is entered for the request query

This refactor also closes #154.