### PR TITLE
Add Stoppable interface for defining a command as stoppable

### DIFF
--- a/framework/vendor/abstracts/AbstractBotCommand.java
+++ b/framework/vendor/abstracts/AbstractBotCommand.java
@@ -6,10 +6,7 @@ import net.dv8tion.jda.core.managers.AccountManager;
 import net.dv8tion.jda.core.managers.GuildController;
 import net.dv8tion.jda.core.requests.restaction.MessageAction;
 import vendor.exceptions.BadContentException;
-import vendor.interfaces.DiscordUtils;
-import vendor.interfaces.Emojis;
-import vendor.interfaces.LinkableCommand;
-import vendor.interfaces.Utils;
+import vendor.interfaces.*;
 import vendor.modules.Logger;
 import vendor.objects.Buffer;
 import vendor.objects.Mention;
@@ -92,8 +89,8 @@ public abstract class AbstractBotCommand extends Translatable implements
 		if(!this.hasContent())
 			return null;
 		
-		ArrayList<String> possibleContent =
-				splitSpacesExcludeQuotesMaxed(this.getContent(), maxSize);
+		ArrayList<String> possibleContent = splitSpacesExcludeQuotesMaxed(
+				this.getContent(), maxSize);
 		
 		return possibleContent.toArray(new String[0]);
 		
@@ -247,11 +244,13 @@ public abstract class AbstractBotCommand extends Translatable implements
 	}
 	
 	public boolean kill(){
-		if(this.stopAction()){
+		
+		if(this instanceof Stoppable && ((Stoppable)this).stopAction()){
 			this.getRouter().interrupt();
 		}
 		
 		return !this.isAlive();
+		
 	}
 	
 	public HashMap<String, Parameter> getParameters(){
@@ -290,10 +289,6 @@ public abstract class AbstractBotCommand extends Translatable implements
 	public void onParameterPresent(String parameterName,
 			Consumer<Parameter> onParamPresent){
 		this.getRequest().onParameterPresent(parameterName, onParamPresent);
-	}
-	
-	public boolean stopAction(){
-		return false;
 	}
 	
 	public void connect(VoiceChannel voiceChannel){

--- a/framework/vendor/interfaces/Stoppable.java
+++ b/framework/vendor/interfaces/Stoppable.java
@@ -1,0 +1,7 @@
+package vendor.interfaces;
+
+public interface Stoppable {
+	
+	boolean stopAction();
+	
+}

--- a/src/commands/CommandClear.java
+++ b/src/commands/CommandClear.java
@@ -8,6 +8,7 @@ import net.dv8tion.jda.core.exceptions.PermissionException;
 import utilities.BotCommand;
 import utilities.specifics.CommandConfirmed;
 import vendor.exceptions.BadContentException;
+import vendor.interfaces.Stoppable;
 import vendor.objects.ParametersHelp;
 
 import java.util.ArrayList;
@@ -20,7 +21,7 @@ import java.util.function.Predicate;
  * 
  * @author Stephano
  */
-public class CommandClear extends BotCommand {
+public class CommandClear extends BotCommand implements Stoppable {
 	
 	@Override
 	public void action(){
@@ -203,10 +204,10 @@ public class CommandClear extends BotCommand {
 		fullHistory.forEach(message -> {
 			
 			// If inverting, the condition must be false to clear this message
-			if(messageCondition.test(message) != invert)
-				messagesWithCondition.add(message);
-			
-		});
+				if(messageCondition.test(message) != invert)
+					messagesWithCondition.add(message);
+				
+			});
 		
 		return messagesWithCondition;
 		
@@ -239,7 +240,10 @@ public class CommandClear extends BotCommand {
 			new ParametersHelp(
 					"Allows you to delete all of the bots messages.", false,
 					"b", "bot"),
-			new ParametersHelp("Inverts the condition applied to the command (example : using this in combination with " + formatParameter("s") + " would clear messages of everyone but yourself).",
+			new ParametersHelp(
+					"Inverts the condition applied to the command (example : using this in combination with "
+							+ formatParameter("s")
+							+ " would clear messages of everyone but yourself).",
 					false, "i", "invert"),
 			new ParametersHelp(
 					"This makes the bot notify the text channel of what it cleared.",

--- a/src/commands/CommandMusicLoop.java
+++ b/src/commands/CommandMusicLoop.java
@@ -58,11 +58,6 @@ public class CommandMusicLoop extends MusicCommands {
 	}
 	
 	@Override
-	public boolean stopAction(){
-		return super.stopAction();
-	}
-	
-	@Override
 	public String getCommandDescription(){
 		return "Skip the song that is currently playing";
 	}

--- a/src/commands/CommandSpam.java
+++ b/src/commands/CommandSpam.java
@@ -5,13 +5,14 @@ import net.dv8tion.jda.core.entities.Member;
 import net.dv8tion.jda.core.entities.Role;
 import utilities.BotCommand;
 import vendor.exceptions.BadContentException;
+import vendor.interfaces.Stoppable;
 import vendor.objects.Mention;
 import vendor.objects.ParametersHelp;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class CommandSpam extends BotCommand {
+public class CommandSpam extends BotCommand implements Stoppable {
 	
 	@Override
 	public void action(){

--- a/src/commands/CommandTimer.java
+++ b/src/commands/CommandTimer.java
@@ -2,9 +2,10 @@ package commands;
 
 import errorHandling.BotError;
 import utilities.BotCommand;
+import vendor.interfaces.Stoppable;
 import vendor.objects.ParametersHelp;
 
-public class CommandTimer extends BotCommand {
+public class CommandTimer extends BotCommand implements Stoppable {
 	
 	private int seconds;
 	private int hours;


### PR DESCRIPTION
This will force the implementation of a `stopAction()` method (which can only return true as it can skip the condition checks).