### PR TITLE
Fix isAlive() to actually get the thread's life status

### DIFF
--- a/framework/vendor/abstracts/AbstractBotCommand.java
+++ b/framework/vendor/abstracts/AbstractBotCommand.java
@@ -243,7 +243,7 @@ public abstract class AbstractBotCommand extends Translatable implements
 	}
 	
 	public boolean isAlive(){
-		return !this.getRouter().isInterrupted();
+		return !this.getRouter().isDead();
 	}
 	
 	public boolean kill(){

--- a/framework/vendor/abstracts/AbstractCommandRouter.java
+++ b/framework/vendor/abstracts/AbstractCommandRouter.java
@@ -20,9 +20,13 @@ public abstract class AbstractCommandRouter extends Thread implements Utils,
 	private MessageEventDigger eventDigger;
 	protected Command command;
 	
+	private boolean isDead;
+	
 	public AbstractCommandRouter(MessageReceivedEvent event,
 			String receivedMessage, Buffer buffer,
 			CommandsRepository commandsRepo){
+		
+		this.isDead = false;
 		
 		this.buffer = buffer;
 		
@@ -179,6 +183,17 @@ public abstract class AbstractCommandRouter extends Thread implements Utils,
 	
 	public LinkableCommand getLinkableCommand(String commandName){
 		return this.getCommandsRepo().getContainer().initiateLink(commandName);
+	}
+
+	@Override
+	public void interrupt() {
+		super.interrupt();
+		
+		this.isDead = true;
+	}
+	
+	public boolean isDead(){
+		return this.isDead;
 	}
 	
 }


### PR DESCRIPTION
This fix is basically tracking the status of the custom Thread via an `isDead` property because `isInterrupted` is not as reliable as one may want : it removes its "interrupted" state after handling the `InterruptedException` exception.

Therefore, we can now know if a command is really alive or not.

Closes #178