### PR TITLE
Tweak EnumSanitizer's extractEnumFromString method (previously formatEnvironmentValue) to test if environment is well formatted

### DIFF
--- a/framework/vendor/utilities/sanitizers/EnumSanitizer.java
+++ b/framework/vendor/utilities/sanitizers/EnumSanitizer.java
@@ -23,20 +23,21 @@ public interface EnumSanitizer {
 	}
 	
 	static ArrayList<String> formatEnvironment(String envKey){
-		return formatEnvironmentValue(Environment.getVar(envKey));
+		return extractEnumFromString(Environment.getVar(envKey));
 	}
 	
-	static ArrayList<String> formatEnvironmentValue(String envValue)
+	static ArrayList<String> extractEnumFromString(String stringValue)
 			throws BadFormatException{
 		
 		// Verify that environment is of format "[...]| [...] | [...]" while allowing single choice enums
 		// Resetting envValue here is not necessary, but this will make it future-proof
-		envValue = TextRegexSanitizer
+		stringValue = TextRegexSanitizer
 				.sanitizeValue(
-						envValue,
+						stringValue,
 						"[^\\n|]*[^\\r\\n\\t\\f\\v |][^\\n|]*(\\|[^\\n|]*[^\\r\\n\\t\\f\\v |][^\\n|]*[^\\n \\t|]*)*");
 		
-		String[] possibleValues = envValue.trim().split("\\s*(?<!\\\\)\\|\\s*");
+		String[] possibleValues = stringValue.trim().split(
+				"\\s*(?<!\\\\)\\|\\s*");
 		
 		ArrayList<String> values = new ArrayList<>();
 		

--- a/framework/vendor/utilities/sanitizers/EnumSanitizer.java
+++ b/framework/vendor/utilities/sanitizers/EnumSanitizer.java
@@ -4,7 +4,6 @@ import vendor.exceptions.BadFormatException;
 import vendor.modules.Environment;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 
 public interface EnumSanitizer {
@@ -37,10 +36,13 @@ public interface EnumSanitizer {
 						envValue,
 						"[^\\n|]*[^\\r\\n\\t\\f\\v |][^\\n|]*(\\|[^\\n|]*[^\\r\\n\\t\\f\\v |][^\\n|]*[^\\n \\t|]*)*");
 		
-		String[] possibleValues = envValue.trim().split("\\s*\\|\\s*");
+		String[] possibleValues = envValue.trim().split("\\s*(?<!\\\\)\\|\\s*");
 		
-		ArrayList<String> values = new ArrayList<>(
-				Arrays.asList(possibleValues));
+		ArrayList<String> values = new ArrayList<>();
+		
+		for(String possibleValue : possibleValues){
+			values.add(possibleValue.replaceAll("\\\\\\|", "|"));
+		}
 		
 		// Remove duplicate while keeping the order of the values
 		LinkedHashSet<String> hs = new LinkedHashSet<>();

--- a/framework/vendor/utilities/sanitizers/EnumSanitizer.java
+++ b/framework/vendor/utilities/sanitizers/EnumSanitizer.java
@@ -30,10 +30,12 @@ public interface EnumSanitizer {
 	static ArrayList<String> formatEnvironmentValue(String envValue)
 			throws BadFormatException{
 		
-		// Verify that environment is of format "[...]| [...] | [...]"
+		// Verify that environment is of format "[...]| [...] | [...]" while allowing single choice enums
 		// Resetting envValue here is not necessary, but this will make it future-proof
-		envValue = TextRegexSanitizer.sanitizeValue(envValue,
-				"([^\\s]+\\s*\\|\\s*[^\\s]+)+");
+		envValue = TextRegexSanitizer
+				.sanitizeValue(
+						envValue,
+						"[^\\n|]*[^\\r\\n\\t\\f\\v |][^\\n|]*(\\|[^\\n|]*[^\\r\\n\\t\\f\\v |][^\\n|]*[^\\n \\t|]*)*");
 		
 		String[] possibleValues = envValue.trim().split("\\s*\\|\\s*");
 		

--- a/framework/vendor/utilities/sanitizers/EnumSanitizer.java
+++ b/framework/vendor/utilities/sanitizers/EnumSanitizer.java
@@ -28,21 +28,29 @@ public interface EnumSanitizer {
 	
 	static ArrayList<String> extractEnumFromString(String stringValue)
 			throws BadFormatException{
+		return extractEnumFromString(stringValue, '|');
+	}
+	
+	static ArrayList<String> extractEnumFromString(String stringValue,
+			char separator) throws BadFormatException{
 		
-		// Verify that environment is of format "[...]| [...] | [...]" while allowing single choice enums
-		// Resetting envValue here is not necessary, but this will make it future-proof
-		stringValue = TextRegexSanitizer
-				.sanitizeValue(
-						stringValue,
-						"[^\\n|]*[^\\r\\n\\t\\f\\v |][^\\n|]*(\\|[^\\n|]*[^\\r\\n\\t\\f\\v |][^\\n|]*[^\\n \\t|]*)*");
+		String pSep = String.format("\\%s", separator);
+		
+		// Verify that environment is of format "[...]| [...] | [...]" while allowing single choice enums.
+		// Please see https://regex101.com/r/FrVwfk for an interactive testing session for this regex.
+		// ~ Resetting stringValue here is not necessary, but this will make it future-proof ~
+		stringValue = TextRegexSanitizer.sanitizeValue(stringValue, "[^\\n"
+				+ pSep + "]*[^\\r\\n\\t\\f\\v " + pSep + "][^\\n" + pSep
+				+ "]*(" + pSep + "[^\\n" + pSep + "]*[^\\r\\n\\t\\f\\v " + pSep
+				+ "][^\\n" + pSep + "]*[^\\n \\t" + pSep + "]*)*");
 		
 		String[] possibleValues = stringValue.trim().split(
-				"\\s*(?<!\\\\)\\|\\s*");
+				"\\s*(?<!\\\\)" + pSep + "\\s*");
 		
 		ArrayList<String> values = new ArrayList<>();
 		
 		for(String possibleValue : possibleValues){
-			values.add(possibleValue.replaceAll("\\\\\\|", "|"));
+			values.add(possibleValue.replaceAll("\\\\" + pSep + "", "|"));
 		}
 		
 		// Remove duplicate while keeping the order of the values

--- a/framework/vendor/utilities/sanitizers/EnumSanitizer.java
+++ b/framework/vendor/utilities/sanitizers/EnumSanitizer.java
@@ -1,11 +1,11 @@
 package vendor.utilities.sanitizers;
 
+import vendor.exceptions.BadFormatException;
+import vendor.modules.Environment;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
-
-import vendor.exceptions.BadFormatException;
-import vendor.modules.Environment;
 
 public interface EnumSanitizer {
 	
@@ -27,14 +27,18 @@ public interface EnumSanitizer {
 		return formatEnvironmentValue(Environment.getVar(envKey));
 	}
 	
-	static ArrayList<String> formatEnvironmentValue(String envValue){
+	static ArrayList<String> formatEnvironmentValue(String envValue)
+			throws BadFormatException{
 		
-		if(envValue == null)
-			return null;
+		// Verify that environment is of format "[...]| [...] | [...]"
+		// Resetting envValue here is not necessary, but this will make it future-proof
+		envValue = TextRegexSanitizer.sanitizeValue(envValue,
+				"([^\\s]+\\s*\\|\\s*[^\\s]+)+");
 		
 		String[] possibleValues = envValue.trim().split("\\s*\\|\\s*");
 		
-		ArrayList<String> values = new ArrayList<>(Arrays.asList(possibleValues));
+		ArrayList<String> values = new ArrayList<>(
+				Arrays.asList(possibleValues));
 		
 		// Remove duplicate while keeping the order of the values
 		LinkedHashSet<String> hs = new LinkedHashSet<>();

--- a/framework/vendor/utilities/sanitizers/TextRegexSanitizer.java
+++ b/framework/vendor/utilities/sanitizers/TextRegexSanitizer.java
@@ -1,9 +1,9 @@
 package vendor.utilities.sanitizers;
 
+import vendor.exceptions.BadFormatException;
+
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-
-import vendor.exceptions.BadFormatException;
 
 public interface TextRegexSanitizer {
 	
@@ -30,7 +30,7 @@ public interface TextRegexSanitizer {
 			boolean isInverted, boolean shouldBox, boolean shouldCheckPattern)
 			throws BadFormatException, PatternSyntaxException{
 		
-		String stringValue = TextSanitizer.sanitizeValue(value);
+		String stringValue = TextNotEmptySanitizer.sanitizeValue(value);
 		
 		if(regexToMatch != null){
 			
@@ -46,7 +46,7 @@ public interface TextRegexSanitizer {
 			// Test regex and invert if we need to
 			if(stringValue.matches(regexToMatch) == isInverted){
 				throw new BadFormatException(
-						"Value does not match the required pattern!", 1);
+						"Value does not match the required pattern!", 2);
 			}
 			
 		}

--- a/framework/vendor/utilities/settings/EnumField.java
+++ b/framework/vendor/utilities/settings/EnumField.java
@@ -1,10 +1,9 @@
 package vendor.utilities.settings;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
 import vendor.exceptions.BadFormatException;
 import vendor.utilities.sanitizers.EnumSanitizer;
+
+import java.util.ArrayList;
 
 public class EnumField extends TextField {
 	
@@ -52,12 +51,7 @@ public class EnumField extends TextField {
 			throws BadFormatException{
 		this.values = new CaseArrayList();
 		
-		try{
-			this.values.addAll(EnumSanitizer.formatEnvironmentValue(envValue));
-		}
-		catch(NullPointerException e){
-			throw new BadFormatException();
-		}
+		this.values.addAll(EnumSanitizer.formatEnvironmentValue(envValue));
 		
 		return this.values.get(0);
 	}

--- a/framework/vendor/utilities/settings/EnumField.java
+++ b/framework/vendor/utilities/settings/EnumField.java
@@ -51,7 +51,7 @@ public class EnumField extends TextField {
 			throws BadFormatException{
 		this.values = new CaseArrayList();
 		
-		this.values.addAll(EnumSanitizer.formatEnvironmentValue(envValue));
+		this.values.addAll(EnumSanitizer.extractEnumFromString(envValue));
 		
 		return this.values.get(0);
 	}


### PR DESCRIPTION
- The `formatEnvironmentValue` method was renamed to `formatStringAsEnum` to better represent its actions (the method was and is still not dependant to the Environment).
- There is also a new method to change the separator of the enum, in case a custom string want to use the power of the EnumSanitizer.

This allows for a greater handling of the formatting expected for enums.

<details><summary>Tests made</summary>
<p>


```java
import org.junit.jupiter.api.Test;
import org.junit.jupiter.api.function.Executable;
import vendor.exceptions.BadFormatException;
import vendor.utilities.sanitizers.EnumSanitizer;

import java.util.ArrayList;

import static org.junit.jupiter.api.Assertions.assertEquals;
import static org.junit.jupiter.api.Assertions.assertThrows;

class EnumSanitizerTest {
	
	@Test
	void testSingleValueNoSpace(){
		
		String value = "Hello!";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(1, list.size());
		assertEquals("Hello!", list.get(0));
		
	}
	
	@Test
	void testSingleValueSpaces(){
		
		String value = "Hello fellow kid!";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(1, list.size());
		assertEquals("Hello fellow kid!", list.get(0));
		
	}
	
	@Test
	void testSingleValueTabs(){
		
		String value = "Hello\tfellow\tkid!";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(1, list.size());
		assertEquals("Hello\tfellow\tkid!", list.get(0));
		
	}
	
	@Test
	void testSingleValueSpacesAndTabs(){
		
		String value = "Hello\t fellow \t kid!";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(1, list.size());
		assertEquals("Hello\t fellow \t kid!", list.get(0));
		
	}
	
	@Test
	void testSingleValueTrailingSpaces(){
		
		String value = "  Hello!  ";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(1, list.size());
		assertEquals("Hello!", list.get(0));
		
	}
	
	@Test
	void testSingleValueTrailingTabs(){
		
		String value = "\tHello!\t";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(1, list.size());
		assertEquals("Hello!", list.get(0));
		
	}
	
	@Test
	void testMultipleValuesNoSpace(){
		
		String value = "First|Second|Third";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(3, list.size());
		assertEquals("First", list.get(0));
		assertEquals("Second", list.get(1));
		assertEquals("Third", list.get(2));
		
	}
	
	@Test
	void testMultipleValuesSpaces(){
		
		String value = "First  |  Second  |  Third";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(3, list.size());
		assertEquals("First", list.get(0));
		assertEquals("Second", list.get(1));
		assertEquals("Third", list.get(2));
		
	}
	
	@Test
	void testMultipleValuesTabs(){
		
		String value = "First\t|\tSecond\t|\tThird";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(3, list.size());
		assertEquals("First", list.get(0));
		assertEquals("Second", list.get(1));
		assertEquals("Third", list.get(2));
		
	}
	
	@Test
	void testMultipleValuesSpacesAndTabs(){
		
		String value = "First\t  | \t Second \t  |\t  Third";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(3, list.size());
		assertEquals("First", list.get(0));
		assertEquals("Second", list.get(1));
		assertEquals("Third", list.get(2));
		
	}
	
	@Test
	void testSingleValueProtectedBar(){
		
		String value = "Hello \\| World";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(1, list.size());
		assertEquals("Hello | World", list.get(0));
		
	}
	
	@Test
	void testMultipleValuesProtectedBar(){
		
		String value = "First \\| Second | Third";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(2, list.size());
		assertEquals("First | Second", list.get(0));
		assertEquals("Third", list.get(1));
		
	}
	
	@Test
	void testSingleValueProtectedProtectedBar(){
		
		String value = "Hello \\\\| World";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(1, list.size());
		assertEquals("Hello \\| World", list.get(0));
		
	}
	
	@Test
	void testMultipleValuesProtectedProtectedBar(){
		
		String value = "First \\\\| Second | Third";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(2, list.size());
		assertEquals("First \\| Second", list.get(0));
		assertEquals("Third", list.get(1));
		
	}
	
	@Test
	void testEmptyValue(){
		
		String value = "";
		
		Executable shouldThrowBadFormatException = () -> {
			EnumSanitizer.extractEnumFromString(value);
		};
		
		assertThrows(BadFormatException.class, shouldThrowBadFormatException);
		
	}
	
	@Test
	void testMultipleValuesBadFormat1(){
		
		String value = "First|";
		
		Executable shouldThrowBadFormatException = () -> {
			EnumSanitizer.extractEnumFromString(value);
		};
		
		assertThrows(BadFormatException.class, shouldThrowBadFormatException);
		
	}
	
	@Test
	void testMultipleValuesBadFormat2(){
		
		String value = "|";
		
		Executable shouldThrowBadFormatException = () -> {
			EnumSanitizer.extractEnumFromString(value);
		};
		
		assertThrows(BadFormatException.class, shouldThrowBadFormatException);
		
	}
	
	@Test
	void testMultipleValuesBadFormat3(){
		
		String value = "First||Third";
		
		Executable shouldThrowBadFormatException = () -> {
			EnumSanitizer.extractEnumFromString(value);
		};
		
		assertThrows(BadFormatException.class, shouldThrowBadFormatException);
		
	}
	
	@Test
	void testMultipleValuesBadFormat4(){
		
		String value = "First|  |Third";
		
		Executable shouldThrowBadFormatException = () -> {
			EnumSanitizer.extractEnumFromString(value);
		};
		
		assertThrows(BadFormatException.class, shouldThrowBadFormatException);
		
	}
	
	@Test
	void testMultipleValuesBadFormat5(){
		
		String value = "First|Second|";
		
		Executable shouldThrowBadFormatException = () -> {
			EnumSanitizer.extractEnumFromString(value);
		};
		
		assertThrows(BadFormatException.class, shouldThrowBadFormatException);
		
	}
	
	@Test
	void testMultipleValuesBadFormat6(){
		
		String value = "|First|Second";
		
		Executable shouldThrowBadFormatException = () -> {
			EnumSanitizer.extractEnumFromString(value);
		};
		
		assertThrows(BadFormatException.class, shouldThrowBadFormatException);
		
	}
	
	@Test
	void testMultipleValuesBadFormat7(){
		
		String value = "    |First";
		
		Executable shouldThrowBadFormatException = () -> {
			EnumSanitizer.extractEnumFromString(value);
		};
		
		assertThrows(BadFormatException.class, shouldThrowBadFormatException);
		
	}
	
	@Test
	void testMultipleValuesBadFormat8(){
		
		String value = "First|    ";
		
		Executable shouldThrowBadFormatException = () -> {
			EnumSanitizer.extractEnumFromString(value);
		};
		
		assertThrows(BadFormatException.class, shouldThrowBadFormatException);
		
	}
	
	@Test
	void testRegexCharInValue(){
		
		String value = "First | Se[ond";
		
		ArrayList<String> list = EnumSanitizer.extractEnumFromString(value);
		
		assertEquals(2, list.size());
		assertEquals("First", list.get(0));
		assertEquals("Se[ond", list.get(1));
		
	}
	
	@Test
	void testSeparatorRegexChar(){
		
		String value = "First [ Second";
		
		ArrayList<String> list = EnumSanitizer
				.extractEnumFromString(value, '[');
		
		assertEquals(2, list.size());
		assertEquals("First", list.get(0));
		assertEquals("Second", list.get(1));
		
	}
	
	@Test
	void testSeparatorRegexCharAndRegexInValue(){
		
		String value = "First [ Secon]";
		
		ArrayList<String> list = EnumSanitizer
				.extractEnumFromString(value, '[');
		
		assertEquals(2, list.size());
		assertEquals("First", list.get(0));
		assertEquals("Secon]", list.get(1));
		
	}
	
}
```

</p>
</details>


~The only failing test is the `testSingleValueProtectedBar()` - there is currently no way to "protect" the `|` character to use it in an enum value. The failing test tries to create a single value that contains a `|` by using `Hello \| World`.~

**Edit** : To allow the `|` character in an enum option, simply escape it using `\`. Therefore, the string `Rope \| | Grill` will have two option : `Rope |` and `Grill`.
To have an option with the text `\|`, simply add an escape char before the escape char : `\\|`. This can be repeated any amount of time desired.
Tests in the summary above have been updated.

**Edit 2** : Added new test after adding the possibility of changing the separator for the enum String.