### PR TITLE
Tweak CommandTimer to run in background by default

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -32,6 +32,7 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Maven: com.squareup.okio:okio:1.13.0"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Maven: org.slf4j:slf4j-simple:1.7.25"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Maven: io.github.classgraph:classgraph:4.4.12"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Maven: io.github.v-ed:jsanitizers:1.0.0"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Maven: com.sedmelluq:lavaplayer:1.2.56"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Maven: com.sedmelluq:lavaplayer-common:1.0.6"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/Maven: com.sedmelluq:lavaplayer-natives:1.2.55"/>

--- a/src/main/java/io/github/vhoyon/bot/app/CommandRouter.java
+++ b/src/main/java/io/github/vhoyon/bot/app/CommandRouter.java
@@ -1,10 +1,10 @@
 package io.github.vhoyon.bot.app;
 
-import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 import io.github.vhoyon.bot.errorHandling.BotError;
 import io.github.vhoyon.bot.errorHandling.BotErrorPrivate;
 import io.github.vhoyon.bot.utilities.abstracts.SimpleTextCommand;
 import io.github.vhoyon.bot.utilities.interfaces.Commands;
+import io.github.vhoyon.bot.utilities.interfaces.PartiallyParallelRunnable;
 import io.github.vhoyon.bot.utilities.interfaces.Resources;
 import io.github.vhoyon.bot.utilities.specifics.CommandConfirmed;
 import io.github.vhoyon.vramework.abstracts.AbstractBotCommand;
@@ -19,6 +19,7 @@ import io.github.vhoyon.vramework.objects.*;
 import io.github.vhoyon.vramework.utilities.CommandsThreadManager;
 import io.github.vhoyon.vramework.utilities.formatting.DiscordFormatter;
 import io.github.vhoyon.vramework.utilities.settings.Setting;
+import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 
 import java.util.ArrayList;
 
@@ -111,16 +112,30 @@ public class CommandRouter extends AbstractCommandRouter implements Resources,
 						
 						String commandName = request.getCommand();
 						
-						if(CommandsThreadManager.isCommandRunning(commandName,
-								eventDigger, this)){
+						// Exception for Timer
+						AbstractBotCommand command = CommandsThreadManager
+								.getCommandRunning(commandName, eventDigger,
+										this);
+						
+						boolean notDuplicateCommand = command == null;
+						
+						setCommand(getLinkableCommand(commandName));
+						
+						if(!notDuplicateCommand
+								&& command instanceof PartiallyParallelRunnable){
+							
+							AbstractBotCommand currentCommand = getAbstractBotCommand();
+							
+							notDuplicateCommand = ((PartiallyParallelRunnable)command)
+									.duplicatedRunnableCondition(
+											currentCommand, command);
+							
+						}
+						
+						if(!notDuplicateCommand){
 							
 							setCommand(new BotError(lang(
 									"CommandIsRunningError", code(commandName))));
-							
-						}
-						else{
-							
-							setCommand(getLinkableCommand(commandName));
 							
 						}
 						

--- a/src/main/java/io/github/vhoyon/bot/app/CommandRouter.java
+++ b/src/main/java/io/github/vhoyon/bot/app/CommandRouter.java
@@ -112,7 +112,6 @@ public class CommandRouter extends AbstractCommandRouter implements Resources,
 						
 						String commandName = request.getCommand();
 						
-						// Exception for Timer
 						AbstractBotCommand command = CommandsThreadManager
 								.getCommandRunning(commandName, eventDigger,
 										this);

--- a/src/main/java/io/github/vhoyon/bot/app/CommandRouter.java
+++ b/src/main/java/io/github/vhoyon/bot/app/CommandRouter.java
@@ -119,10 +119,10 @@ public class CommandRouter extends AbstractCommandRouter implements Resources,
 						
 						boolean notDuplicateCommand = command == null;
 						
-						setCommand(getLinkableCommand(commandName));
-						
 						if(!notDuplicateCommand
 								&& command instanceof PartiallyParallelRunnable){
+							
+							setCommand(getLinkableCommand(commandName));
 							
 							AbstractBotCommand currentCommand = getAbstractBotCommand();
 							
@@ -137,6 +137,9 @@ public class CommandRouter extends AbstractCommandRouter implements Resources,
 							setCommand(new BotError(lang(
 									"CommandIsRunningError", code(commandName))));
 							
+						}
+						else if(getCommand() == null){
+							setCommand(getLinkableCommand(commandName));
 						}
 						
 					}

--- a/src/main/java/io/github/vhoyon/bot/commands/CommandTimer.java
+++ b/src/main/java/io/github/vhoyon/bot/commands/CommandTimer.java
@@ -128,65 +128,7 @@ public class CommandTimer extends BotCommand implements Stoppable,
 			}
 			
 			if(!shouldShowTimer.get()){
-				
-				MessageManager manager = new MessageManager();
-				
-				manager.addMessage(
-						1,
-						"A timer is set for {1} hours - use the {2} command without arguments / parameters to see the current progress!",
-						"hours", "timer");
-				manager.addMessage(
-						2,
-						"A timer is set for {1} minutes - use the {2} command without arguments / parameters to see the current progress!",
-						"minutes", "timer");
-				manager.addMessage(
-						3,
-						"A timer is set for {1} hours and {2} minutes - use the {3} command without arguments / parameters to see the current progress!",
-						"hours", "minutes", "timer");
-				manager.addMessage(
-						4,
-						"A timer is set for {1} seconds - use the {2} command without arguments / parameters to see the current progress!",
-						"seconds", "timer");
-				manager.addMessage(
-						5,
-						"A timer is set for {1} hours and {2} seconds - use the {3} command without arguments / parameters to see the current progress!",
-						"hours", "seconds", "timer");
-				manager.addMessage(
-						6,
-						"A timer is set for {1} minutes and {2} seconds - use the {3} command without arguments / parameters to see the current progress!",
-						"minutes", "seconds", "timer");
-				manager.addMessage(
-						7,
-						"A timer is set for {1} hours, {2} minutes and {3} seconds - use the {3} command without arguments / parameters to see the current progress!",
-						"hours", "minutes", "seconds", "timer");
-				
-				int indice = 0;
-				
-				if(hours > 0){
-					indice += 1;
-					manager.addReplacement("hours", hours);
-				}
-				if(minutes > 0){
-					indice += 2;
-					manager.addReplacement("minutes", minutes);
-				}
-				if(seconds > 0){
-					indice += 4;
-					manager.addReplacement("seconds", seconds);
-				}
-				manager.addReplacement("timer", buildVCommand(TIMER));
-				
-				sendInfoMessage(manager.getMessageRaw(indice).toString());
-				
-				Object handler = new Object();
-				
-				TimerManager.schedule("CommandTimer" + getKey(),
-						totalTime * 1000, () -> {}, handler);
-				
-				synchronized(handler){
-					handler.wait();
-				}
-				
+				createTimerBackground(totalTime);
 			}
 			
 			if(isAlive())
@@ -220,6 +162,77 @@ public class CommandTimer extends BotCommand implements Stoppable,
 			}
 			
 		}
+		
+	}
+	
+	private void createTimerBackground(int totalTime)
+			throws InterruptedException{
+		
+		MessageManager manager = setupMessageManager();
+		
+		int indice = 0;
+		
+		if(hours > 0){
+			indice += 1;
+			manager.addReplacement("hours", hours);
+		}
+		if(minutes > 0){
+			indice += 2;
+			manager.addReplacement("minutes", minutes);
+		}
+		if(seconds > 0){
+			indice += 4;
+			manager.addReplacement("seconds", seconds);
+		}
+		manager.addReplacement("timer", buildVCommand(TIMER));
+		
+		sendInfoMessage(manager.getMessageRaw(indice).toString());
+		
+		Object handler = new Object();
+		
+		TimerManager.schedule("CommandTimer" + getKey(), totalTime * 1000,
+				() -> {}, handler);
+		
+		synchronized(handler){
+			handler.wait();
+		}
+		
+	}
+	
+	private MessageManager setupMessageManager(){
+		
+		MessageManager manager = new MessageManager();
+		
+		manager.addMessage(
+				1,
+				"A timer is set for {1} hours - use the {2} command without arguments / parameters to see the current progress!",
+				"hours", "timer");
+		manager.addMessage(
+				2,
+				"A timer is set for {1} minutes - use the {2} command without arguments / parameters to see the current progress!",
+				"minutes", "timer");
+		manager.addMessage(
+				3,
+				"A timer is set for {1} hours and {2} minutes - use the {3} command without arguments / parameters to see the current progress!",
+				"hours", "minutes", "timer");
+		manager.addMessage(
+				4,
+				"A timer is set for {1} seconds - use the {2} command without arguments / parameters to see the current progress!",
+				"seconds", "timer");
+		manager.addMessage(
+				5,
+				"A timer is set for {1} hours and {2} seconds - use the {3} command without arguments / parameters to see the current progress!",
+				"hours", "seconds", "timer");
+		manager.addMessage(
+				6,
+				"A timer is set for {1} minutes and {2} seconds - use the {3} command without arguments / parameters to see the current progress!",
+				"minutes", "seconds", "timer");
+		manager.addMessage(
+				7,
+				"A timer is set for {1} hours, {2} minutes and {3} seconds - use the {3} command without arguments / parameters to see the current progress!",
+				"hours", "minutes", "seconds", "timer");
+		
+		return manager;
 		
 	}
 	

--- a/src/main/java/io/github/vhoyon/bot/commands/CommandTimer.java
+++ b/src/main/java/io/github/vhoyon/bot/commands/CommandTimer.java
@@ -8,7 +8,7 @@ import io.github.vhoyon.vramework.exceptions.BadFormatException;
 import io.github.vhoyon.vramework.interfaces.Stoppable;
 import io.github.vhoyon.vramework.objects.ParametersHelp;
 import io.github.vhoyon.vramework.utilities.TimerManager;
-import io.github.vhoyon.vramework.utilities.sanitizers.IntegerSanitizer;
+import io.github.ved.jsanitizers.IntegerSanitizer;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/src/main/java/io/github/vhoyon/bot/commands/CommandTimer.java
+++ b/src/main/java/io/github/vhoyon/bot/commands/CommandTimer.java
@@ -186,7 +186,7 @@ public class CommandTimer extends BotCommand implements Stoppable,
 		}
 		manager.addReplacement("timer", buildVCommand(TIMER));
 		
-		sendInfoMessage(manager.getMessageRaw(indice).toString());
+		sendInfoMessage(manager.getMessage(indice, getDictionary(), this));
 		
 		Object handler = new Object();
 		
@@ -203,34 +203,15 @@ public class CommandTimer extends BotCommand implements Stoppable,
 		
 		MessageManager manager = new MessageManager();
 		
-		manager.addMessage(
-				1,
-				"A timer is set for {1} hours - use the {2} command without arguments / parameters to see the current progress!",
-				"hours", "timer");
-		manager.addMessage(
-				2,
-				"A timer is set for {1} minutes - use the {2} command without arguments / parameters to see the current progress!",
-				"minutes", "timer");
-		manager.addMessage(
-				3,
-				"A timer is set for {1} hours and {2} minutes - use the {3} command without arguments / parameters to see the current progress!",
-				"hours", "minutes", "timer");
-		manager.addMessage(
-				4,
-				"A timer is set for {1} seconds - use the {2} command without arguments / parameters to see the current progress!",
+		manager.addMessage(1, "BackHours", "hours", "timer");
+		manager.addMessage(2, "BackMinutes", "minutes", "timer");
+		manager.addMessage(3, "BackHoursMinutes", "hours", "minutes", "timer");
+		manager.addMessage(4, "BackSeconds", "seconds", "timer");
+		manager.addMessage(5, "BackHoursSeconds", "hours", "seconds", "timer");
+		manager.addMessage(6, "BackMinutesSeconds", "minutes", "seconds",
+				"timer");
+		manager.addMessage(7, "BackHoursMinutesSeconds", "hours", "minutes",
 				"seconds", "timer");
-		manager.addMessage(
-				5,
-				"A timer is set for {1} hours and {2} seconds - use the {3} command without arguments / parameters to see the current progress!",
-				"hours", "seconds", "timer");
-		manager.addMessage(
-				6,
-				"A timer is set for {1} minutes and {2} seconds - use the {3} command without arguments / parameters to see the current progress!",
-				"minutes", "seconds", "timer");
-		manager.addMessage(
-				7,
-				"A timer is set for {1} hours, {2} minutes and {3} seconds - use the {3} command without arguments / parameters to see the current progress!",
-				"hours", "minutes", "seconds", "timer");
 		
 		return manager;
 		

--- a/src/main/java/io/github/vhoyon/bot/commands/CommandTimer.java
+++ b/src/main/java/io/github/vhoyon/bot/commands/CommandTimer.java
@@ -2,8 +2,16 @@ package io.github.vhoyon.bot.commands;
 
 import io.github.vhoyon.bot.errorHandling.BotError;
 import io.github.vhoyon.bot.utilities.BotCommand;
+import io.github.vhoyon.bot.utilities.interfaces.PartiallyParallelRunnable;
+import io.github.vhoyon.vramework.abstracts.AbstractBotCommand;
+import io.github.vhoyon.vramework.exceptions.BadFormatException;
 import io.github.vhoyon.vramework.interfaces.Stoppable;
 import io.github.vhoyon.vramework.objects.ParametersHelp;
+import io.github.vhoyon.vramework.utilities.TimerManager;
+import io.github.vhoyon.vramework.utilities.sanitizers.IntegerSanitizer;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Command to create a timer in the TextChannel where this command was called
@@ -13,7 +21,8 @@ import io.github.vhoyon.vramework.objects.ParametersHelp;
  * @since v0.4.0
  * @author V-ed (Guillaume Marcoux)
  */
-public class CommandTimer extends BotCommand implements Stoppable {
+public class CommandTimer extends BotCommand implements Stoppable,
+		PartiallyParallelRunnable {
 	
 	private int seconds;
 	private int hours;
@@ -21,6 +30,25 @@ public class CommandTimer extends BotCommand implements Stoppable {
 	
 	@Override
 	public void action(){
+		
+		if(!hasContent() && !getRequest().hasParameters()){
+			
+			try{
+				
+				int timeRemaining = TimerManager
+						.getTimeRemaining("CommandTimer" + getKey()) / 1000;
+				
+				timeConstruct(timeRemaining);
+				
+				sendMessage("Time remaining : "
+						+ formatDate(hours, minutes, seconds));
+				
+				return;
+				
+			}
+			catch(NullPointerException e){}
+			
+		}
 		
 		seconds = 0;
 		hours = 0;
@@ -32,7 +60,6 @@ public class CommandTimer extends BotCommand implements Stoppable {
 				throw new NullPointerException();
 			}
 			
-			// seconds = Integer.parseInt(constraints[0]);
 			if(hasParameter("h")){
 				hours = Integer.parseInt(getParameter("h").getContent());
 			}
@@ -44,18 +71,74 @@ public class CommandTimer extends BotCommand implements Stoppable {
 			}
 			
 			int totalTime = (hours * 3600) + (minutes * 60) + seconds;
-			String timerMessageId = null;
-			timeConstruct(totalTime);
-			timerMessageId = sendMessage(formatDate(hours, minutes, seconds));
 			
-			for(int i = totalTime; i >= 0 && isAlive(); i--){
+			timeConstruct(totalTime);
+			
+			AtomicBoolean shouldShowTimer = new AtomicBoolean(hasParameter("v",
+					"r"));
+			
+			if(shouldShowTimer.get()){
 				
-				if(i < totalTime){
-					Thread.sleep(1000);
+				AtomicInteger refreshRateRef = new AtomicInteger(1);
+				
+				onParameterPresent(
+						"r",
+						parameter -> {
+							try{
+								
+								int refreshRate = IntegerSanitizer
+										.sanitizeValue(parameter.getContent(),
+												1, totalTime);
+								
+								refreshRateRef.set(refreshRate);
+								
+							}
+							catch(BadFormatException e){
+								if(e.getErrorCode() != 4)
+									throw e;
+								
+								shouldShowTimer.set(false);
+							}
+						});
+				
+				if(shouldShowTimer.get()){
 					
-					timeConstruct(i);
-					editMessageQueue(timerMessageId,
-							formatDate(hours, minutes, seconds));
+					String timerMessageId = null;
+					timerMessageId = sendMessage(formatDate(hours, minutes,
+							seconds));
+					
+					int refreshRate = refreshRateRef.get();
+					
+					for(int i = totalTime; i >= 0 && isAlive(); i -= refreshRate){
+						
+						if(i < totalTime){
+							Thread.sleep(1000 * refreshRate);
+							
+							timeConstruct(i);
+							
+							editMessageQueue(timerMessageId,
+									formatDate(hours, minutes, seconds));
+						}
+						
+					}
+					
+				}
+				
+			}
+			
+			if(!shouldShowTimer.get()){
+				
+				sendInfoMessage(format(
+						"A timer is set for {1} hour - use the {2} command without arguments / parameters to see the current progress!",
+						hours, buildVCommand(TIMER)));
+				
+				Object handler = new Object();
+				
+				TimerManager.schedule("CommandTimer" + getKey(),
+						totalTime * 1000, () -> {}, handler);
+				
+				synchronized(handler){
+					handler.wait();
 				}
 				
 			}
@@ -64,13 +147,32 @@ public class CommandTimer extends BotCommand implements Stoppable {
 				sendMessage("TimerEnded");
 			
 		}
-		catch(InterruptedException | IllegalStateException e){}
+		catch(InterruptedException | IllegalStateException e){
+			TimerManager.stopTimer("CommandTimer" + getKey());
+		}
 		catch(NullPointerException e){
-			sendMessage("You must give an amount of time to the "
-					+ buildVCommand("timer") + " command for it to count");
+			new BotError(this, "You must give an amount of time to the "
+					+ buildVCommand("timer") + " command for it to count.");
 		}
 		catch(NumberFormatException e){
 			new BotError(this, "One of the value provided isn't a number!");
+		}
+		catch(BadFormatException e){
+			
+			switch(e.getErrorCode()){
+			case 1:
+				new BotError(this, "Refresh rate's parameter cannot be empty!");
+				break;
+			case 2:
+				new BotError(this,
+						"The value given to the refresh rate parameter isn't a number!");
+				break;
+			case 3:
+				new BotError(this,
+						"The number given to the refresh rate parameter needs to be 1 or more!");
+				break;
+			}
+			
 		}
 		
 	}
@@ -141,7 +243,22 @@ public class CommandTimer extends BotCommand implements Stoppable {
 					"minutes"),
 			new ParametersHelp("Sets the seconds of the timer.", "s", "second",
 					"seconds"),
+			new ParametersHelp("Displays the timer in real time.", "v",
+					"visual"),
+			new ParametersHelp(
+					"Sets the rate (in seconds) at which the visual timer should be updated. This parameter implies the use of the parameter "
+							+ buildVParameter("v")
+							+ ", therefore making the latter redundant when this is used.",
+					"r", "rate", "refresh_rate"),
 		};
+	}
+	
+	@Override
+	public boolean duplicatedRunnableCondition(AbstractBotCommand thisCommand,
+			AbstractBotCommand runningCommand){
+		return thisCommand.getCommandName().equals(TIMER)
+				&& !thisCommand.hasContent()
+				&& !thisCommand.getRequest().hasParameters();
 	}
 	
 }

--- a/src/main/java/io/github/vhoyon/bot/commands/CommandTimer.java
+++ b/src/main/java/io/github/vhoyon/bot/commands/CommandTimer.java
@@ -7,6 +7,7 @@ import io.github.vhoyon.vramework.abstracts.AbstractBotCommand;
 import io.github.vhoyon.vramework.exceptions.BadFormatException;
 import io.github.vhoyon.vramework.interfaces.Stoppable;
 import io.github.vhoyon.vramework.objects.ParametersHelp;
+import io.github.vhoyon.vramework.utilities.MessageManager;
 import io.github.vhoyon.vramework.utilities.TimerManager;
 import io.github.ved.jsanitizers.IntegerSanitizer;
 
@@ -128,9 +129,54 @@ public class CommandTimer extends BotCommand implements Stoppable,
 			
 			if(!shouldShowTimer.get()){
 				
-				sendInfoMessage(format(
-						"A timer is set for {1} hour - use the {2} command without arguments / parameters to see the current progress!",
-						hours, buildVCommand(TIMER)));
+				MessageManager manager = new MessageManager();
+				
+				manager.addMessage(
+						1,
+						"A timer is set for {1} hours - use the {2} command without arguments / parameters to see the current progress!",
+						"hours", "timer");
+				manager.addMessage(
+						2,
+						"A timer is set for {1} minutes - use the {2} command without arguments / parameters to see the current progress!",
+						"minutes", "timer");
+				manager.addMessage(
+						3,
+						"A timer is set for {1} hours and {2} minutes - use the {3} command without arguments / parameters to see the current progress!",
+						"hours", "minutes", "timer");
+				manager.addMessage(
+						4,
+						"A timer is set for {1} seconds - use the {2} command without arguments / parameters to see the current progress!",
+						"seconds", "timer");
+				manager.addMessage(
+						5,
+						"A timer is set for {1} hours and {2} seconds - use the {3} command without arguments / parameters to see the current progress!",
+						"hours", "seconds", "timer");
+				manager.addMessage(
+						6,
+						"A timer is set for {1} minutes and {2} seconds - use the {3} command without arguments / parameters to see the current progress!",
+						"minutes", "seconds", "timer");
+				manager.addMessage(
+						7,
+						"A timer is set for {1} hours, {2} minutes and {3} seconds - use the {3} command without arguments / parameters to see the current progress!",
+						"hours", "minutes", "seconds", "timer");
+				
+				int indice = 0;
+				
+				if(hours > 0){
+					indice += 1;
+					manager.addReplacement("hours", hours);
+				}
+				if(minutes > 0){
+					indice += 2;
+					manager.addReplacement("minutes", minutes);
+				}
+				if(seconds > 0){
+					indice += 4;
+					manager.addReplacement("seconds", seconds);
+				}
+				manager.addReplacement("timer", buildVCommand(TIMER));
+				
+				sendInfoMessage(manager.getMessageRaw(indice).toString());
 				
 				Object handler = new Object();
 				

--- a/src/main/java/io/github/vhoyon/bot/utilities/interfaces/PartiallyParallelRunnable.java
+++ b/src/main/java/io/github/vhoyon/bot/utilities/interfaces/PartiallyParallelRunnable.java
@@ -1,0 +1,9 @@
+package io.github.vhoyon.bot.utilities.interfaces;
+
+import io.github.vhoyon.vramework.abstracts.AbstractBotCommand;
+
+public interface PartiallyParallelRunnable {
+	
+	boolean duplicatedRunnableCondition(AbstractBotCommand thisCommand, AbstractBotCommand runningCommand);
+	
+}

--- a/src/main/resources/lang/strings_en_US.properties
+++ b/src/main/resources/lang/strings_en_US.properties
@@ -140,3 +140,11 @@ CommandClearNotifBotInv=Cleared every messages other than mine's!
 
 # End of CommandClear's confirmation and notification message table
 # -----
+
+CommandTimerBackHours=A timer is set for {1} hours - use the {2} command without arguments / parameters to see the current progress!
+CommandTimerBackMinutes=A timer is set for {1} minutes - use the {2} command without arguments / parameters to see the current progress!
+CommandTimerBackHoursMinutes=A timer is set for {1} hours and {2} minutes - use the {3} command without arguments / parameters to see the current progress!
+CommandTimerBackSeconds=A timer is set for {1} seconds - use the {2} command without arguments / parameters to see the current progress!
+CommandTimerBackHoursSeconds=A timer is set for {1} hours and {2} seconds - use the {3} command without arguments / parameters to see the current progress!
+CommandTimerBackMinutesSeconds=A timer is set for {1} minutes and {2} seconds - use the {3} command without arguments / parameters to see the current progress!
+CommandTimerBackHoursMinutesSeconds=A timer is set for {1} hours, {2} minutes and {3} seconds - use the {3} command without arguments / parameters to see the current progress!


### PR DESCRIPTION
In order to actually be able to type `\timer` when the timer runs in background to show the time remaining, I had to implement an `PartiallyParallelRunnable`, which tells the CommandRouter that it may be able to run as a duplicate based on a condition (the duplicated command is given as context for more control in conditions).

### TODO :
- [x] Change message sent to show the right time (it currently only shows `A timer is set for 1 hour`, but if the time is like 20 minutes, it'll show `A timer is set for 0 hour`, which is weird)
- [x] Refactor the background logic to put the logic in its own method for smaller `action()` method footprint
- [x] Move messages to lang strings file

Closes #168 