### PR TITLE
Add handling of user voice updates to disconnect the bot if alone

### DIFF
--- a/src/main/java/io/github/vhoyon/bot/app/MessageListener.java
+++ b/src/main/java/io/github/vhoyon/bot/app/MessageListener.java
@@ -1,20 +1,32 @@
 package io.github.vhoyon.bot.app;
 
+import net.dv8tion.jda.core.entities.Guild;
+import net.dv8tion.jda.core.entities.VoiceChannel;
+import net.dv8tion.jda.core.events.guild.voice.GuildVoiceJoinEvent;
+import net.dv8tion.jda.core.events.guild.voice.GuildVoiceLeaveEvent;
+import net.dv8tion.jda.core.events.guild.voice.GuildVoiceMoveEvent;
+import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
 import io.github.vhoyon.bot.utilities.interfaces.Resources;
+import io.github.vhoyon.bot.utilities.music.MusicManager;
 import io.github.vhoyon.vramework.abstracts.AbstractCommandRouter;
 import io.github.vhoyon.vramework.abstracts.AbstractMessageListener;
 import io.github.vhoyon.vramework.abstracts.CommandsLinker;
 import io.github.vhoyon.vramework.objects.Buffer;
 import io.github.vhoyon.vramework.objects.CommandsRepository;
-import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
+import io.github.vhoyon.vramework.objects.EventDigger;
+import io.github.vhoyon.vramework.utilities.KeyBuilder;
+import io.github.vhoyon.vramework.utilities.TimerManager;
+import io.github.vhoyon.vramework.utilities.settings.SettingRepository;
+import io.github.vhoyon.vramework.utilities.settings.SettingRepositoryRepository;
 
 /**
  * This class implements the logic used by the
- * {@link io.github.vhoyon.vramework.abstracts.AbstractMessageListener AbstractMessageListener}
- * class to create the right {@link io.github.vhoyon.vramework.abstracts.CommandsLinker
+ * {@link io.github.vhoyon.vramework.abstracts.AbstractMessageListener
+ * AbstractMessageListener} class to create the right
+ * {@link io.github.vhoyon.vramework.abstracts.CommandsLinker
  * CommandsLinker} (our {@link BotCommandsLinker}) and create the appropriate
- * {@link io.github.vhoyon.vramework.abstracts.AbstractCommandRouter AbstractCommandRouter} (our
- * {@link CommandRouter}).
+ * {@link io.github.vhoyon.vramework.abstracts.AbstractCommandRouter
+ * AbstractCommandRouter} (our {@link CommandRouter}).
  * 
  * @version 1.0
  * @since 0.1.0
@@ -34,6 +46,90 @@ public class MessageListener extends AbstractMessageListener implements
 			String receivedMessage, Buffer buffer,
 			CommandsRepository commandsRepo){
 		return new CommandRouter(event, receivedMessage, buffer, commandsRepo);
+	}
+	
+	@Override
+	public void onGuildVoiceLeave(GuildVoiceLeaveEvent event){
+		
+		if(!EventDigger.isUserBot(event.getMember())){
+			triggerUserLeftEvent(event.getGuild());
+		}
+		
+	}
+	
+	@Override
+	public void onGuildVoiceMove(GuildVoiceMoveEvent event){
+		
+		if(!EventDigger.isUserBot(event.getMember())){
+			
+			Guild guild = event.getGuild();
+			
+			if(!stopTimerIfChannelIsSameOfBot(event.getChannelJoined(), guild)){
+				
+				triggerUserLeftEvent(guild);
+				
+			}
+			
+		}
+		
+	}
+	
+	private void triggerUserLeftEvent(Guild guild){
+		
+		if(MusicManager.get().hasPlayer(guild)
+				&& !EventDigger.doesConnectedChannelHasHumansLeft(guild)){
+			
+			String userLeftGuildKey = KeyBuilder.buildGuildObjectKey(guild,
+					"USER_LEFT");
+			
+			TimerManager.stopTimer("noPlayerDisconnect");
+			
+			Buffer buffer = Buffer.get();
+			
+			buffer.push(guild, userLeftGuildKey);
+			
+			SettingRepository settings = SettingRepositoryRepository
+					.getSettingRepository(guild, SETTINGS);
+			
+			int aloneDropDelay = settings.getFieldValue("alone_drop_delay");
+			
+			TimerManager.schedule("noPlayerDisconnect", aloneDropDelay, () -> {
+				
+				if(!EventDigger.doesConnectedChannelHasHumansLeft(guild)){
+					MusicManager.get().emptyPlayer(guild);
+				}
+				
+			}, () -> buffer.remove(userLeftGuildKey));
+			
+		}
+		
+	}
+	
+	@Override
+	public void onGuildVoiceJoin(GuildVoiceJoinEvent event){
+		
+		if(!EventDigger.isUserBot(event.getMember())){
+			
+			stopTimerIfChannelIsSameOfBot(event.getChannelJoined(),
+					event.getGuild());
+			
+		}
+		
+	}
+	
+	private boolean stopTimerIfChannelIsSameOfBot(VoiceChannel channel,
+			Guild guild){
+		
+		if(channel.equals(guild.getAudioManager().getConnectedChannel())){
+			
+			TimerManager.stopTimer("noPlayerDisconnect");
+			
+			return true;
+			
+		}
+		
+		return false;
+		
 	}
 	
 }

--- a/src/main/java/io/github/vhoyon/bot/commands/CommandSetting.java
+++ b/src/main/java/io/github/vhoyon/bot/commands/CommandSetting.java
@@ -281,6 +281,14 @@ public class CommandSetting extends BotCommand {
 			}
 		};
 		
+		new SettingChanger<Integer>("alone_drop_delay"){
+			@Override
+			public void onSuccess(Integer delay){
+				sendMessage("The default disconnect delay for the bot when he gets alone is now "
+						+ code(delay) + "!");
+			}
+		};
+		
 	}
 	
 	@Override
@@ -329,6 +337,11 @@ public class CommandSetting extends BotCommand {
 							+ code(getSettings().getField("empty_drop_delay")
 									.getDefaultValue()) + "ms.",
 					"empty_drop_delay"),
+			new ParametersHelp(
+					"Changes the bot's default disconnect time when the bot is not with humans anymore. The default is "
+							+ code(getSettings().getField("alone_drop_delay")
+									.getDefaultValue()) + "ms.",
+					"alone_drop_delay"),
 			new ParametersHelp(
 					"Switch to allow for putting back the default value for each settings as parameters quickly.",
 					false, "d", "default")

--- a/src/main/java/io/github/vhoyon/bot/commands/CommandSetting.java
+++ b/src/main/java/io/github/vhoyon/bot/commands/CommandSetting.java
@@ -4,6 +4,7 @@ import io.github.vhoyon.bot.errorHandling.BotError;
 import io.github.vhoyon.bot.utilities.BotCommand;
 import io.github.vhoyon.bot.utilities.music.MusicManager;
 import io.github.vhoyon.vramework.exceptions.BadFormatException;
+import io.github.vhoyon.vramework.interfaces.BufferLevel;
 import io.github.vhoyon.vramework.modules.Logger;
 import io.github.vhoyon.vramework.objects.ParametersHelp;
 import io.github.vhoyon.vramework.objects.Request.Parameter;
@@ -95,7 +96,9 @@ public class CommandSetting extends BotCommand {
 			
 			if(parameterContent == null){
 				
-				Setting<Object> settingField = getSettings().getField(
+				BufferLevel level = isForGuild() ? BufferLevel.SERVER : null;
+				
+				Setting<Object> settingField = getSettings(level).getField(
 						this.settingName);
 				
 				if(CommandSetting.this.shouldSwitchToDefault){
@@ -128,7 +131,12 @@ public class CommandSetting extends BotCommand {
 			else{
 				
 				try{
-					setSetting(settingName, parameterContent, onSuccess);
+					
+					BufferLevel level = isForGuild() ? BufferLevel.SERVER
+							: null;
+					
+					setSetting(settingName, parameterContent, level, onSuccess);
+					
 				}
 				catch(BadFormatException e){
 					new BotError(this, e.getMessage());
@@ -139,6 +147,10 @@ public class CommandSetting extends BotCommand {
 		}
 		
 		public abstract void onSuccess(T value);
+		
+		public boolean isForGuild(){
+			return hasParameter("g");
+		}
 		
 		public boolean isPresent(){
 			return this.isPresent;
@@ -279,6 +291,11 @@ public class CommandSetting extends BotCommand {
 				sendMessage("The default disconnect delay for the bot when the music player is empty is now "
 						+ code(delay) + "!");
 			}
+			
+			@Override
+			public boolean isForGuild(){
+				return true;
+			}
 		};
 		
 		new SettingChanger<Integer>("alone_drop_delay"){
@@ -286,6 +303,11 @@ public class CommandSetting extends BotCommand {
 			public void onSuccess(Integer delay){
 				sendMessage("The default disconnect delay for the bot when he gets alone is now "
 						+ code(delay) + "!");
+			}
+			
+			@Override
+			public boolean isForGuild(){
+				return true;
 			}
 		};
 		
@@ -344,7 +366,10 @@ public class CommandSetting extends BotCommand {
 					"alone_drop_delay"),
 			new ParametersHelp(
 					"Switch to allow for putting back the default value for each settings as parameters quickly.",
-					false, "d", "default")
+					false, "d", "default"),
+			new ParametersHelp(
+					"Switch to allow for setting the values to the Guild level instead of the TextChannel.",
+					false, "g", "guild"),
 		};
 	}
 	

--- a/src/main/java/io/github/vhoyon/bot/utilities/interfaces/Resources.java
+++ b/src/main/java/io/github/vhoyon/bot/utilities/interfaces/Resources.java
@@ -35,7 +35,9 @@ public interface Resources {
 		new BooleanField("confirm_stop", "SHOULD_CONFIRM_STOP", true),
 		new IntegerField("volume", "DEFAULT_VOLUME", 60, 0, 100),
 		new IntegerField("empty_drop_delay", "MUSIC_EMPTY_DISCONNECT_DELAY",
-				30000, 0, Integer.MAX_VALUE)
+				30000, 0, Integer.MAX_VALUE),
+		new IntegerField("alone_drop_delay", "MUSIC_ALONE_DISCONNECT_DELAY",
+				15000, 0, Integer.MAX_VALUE),
 	};
 	
 }

--- a/src/main/java/io/github/vhoyon/bot/utilities/music/MusicManager.java
+++ b/src/main/java/io/github/vhoyon/bot/utilities/music/MusicManager.java
@@ -8,6 +8,7 @@ import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import io.github.vhoyon.bot.utilities.BotCommand;
+import io.github.vhoyon.vramework.interfaces.BufferLevel;
 import io.github.vhoyon.vramework.interfaces.Utils;
 import net.dv8tion.jda.core.entities.Guild;
 
@@ -101,7 +102,7 @@ public class MusicManager implements Utils {
 	 */
 	public synchronized MusicPlayer getPlayer(BotCommand command){
 		return this.getPlayer(command.getGuild(),
-				command.setting("empty_drop_delay"));
+				command.setting("empty_drop_delay", BufferLevel.SERVER));
 	}
 	
 	/**


### PR DESCRIPTION
Added `alone_drop_delay` setting to the settings options, and `MUSIC_ALONE_DISCONNECT_DELAY` environment variable to control this setting.

There is currently an issue where the setting isn't updated in the Guild settings, but rather the TextChannel settings - this is expected, as there is currently no quick and easy way of saving a setting to the Guild keystore in the CommandSetting command. This should be looked at for this PR to be complete.

TODO :
- [x] Add handling of Guild only settings in CommandSetting
    - [x] Finish implementation of `alone_drop_delay` once guild settings in CommandSetting will be complete

Closes #31