### PR TITLE
Fixed command setting confirm_stop

### DIFF
--- a/src/main/java/io/github/vhoyon/bot/commands/CommandSetting.java
+++ b/src/main/java/io/github/vhoyon/bot/commands/CommandSetting.java
@@ -353,7 +353,7 @@ public class CommandSetting extends BotCommand {
 			new Option(lang("OptionNickname", code(getSetting("nickname")
 					.getDefaultValue())), "nickname"),
 			new Option(lang("OptionConfirmStop", code("true"), code("false"),
-					code(getSetting("nickname").getDefaultValue())),
+					code(getSetting("confirm_stop").getDefaultValue())),
 					"confirm_stop"),
 			new Option(lang("OptionVolume", code(getSetting("volume")
 					.getDefaultValue())), "volume"),


### PR DESCRIPTION
Fixed the bug that happenned with the confirm_stop command, which showed the default nickname was Vhoyon.

Closes #213